### PR TITLE
tagdetails: View details of a tag (PROJQUAY-3545)

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,13 @@ http.createServer(function (request, response) {
             if (err) { // There was an error serving the file
                 console.error("Error serving " + request.url + " - " + err.message);
 
+                if (err.status === 404) { // If the file wasn't found, serve index.html
+                    console.error("serving index.html instead");
+                    fileServer.serveFile('./dist/index.html', 200, {}, request, response);
+                    return;
+                }
+
+
                 // Respond to the client
                 response.writeHead(err.status, err.headers);
                 response.end();

--- a/src/components/shared/Repository/Tabs/Tags/Table.tsx
+++ b/src/components/shared/Repository/Tabs/Tags/Table.tsx
@@ -198,7 +198,7 @@ export default function Table(props: TableProps) {
                 </Td>
                 <Td dataLabel={columnNames.OS}>os-mock</Td>
                 <Td dataLabel={columnNames.Security}>
-                  {typeof tag.manifest_list != 'undefined' ? (
+                  {tag.is_manifest_list ? (
                     'See Child Manifest'
                   ) : (
                     <SecurityDetails
@@ -209,7 +209,7 @@ export default function Table(props: TableProps) {
                   )}
                 </Td>
                 <Td dataLabel={columnNames.Size}>
-                  {typeof tag.manifest_list != 'undefined' ? 'N/A' : tag.size}
+                  {tag.is_manifest_list ? 'N/A' : tag.size}
                 </Td>
                 <Td dataLabel={columnNames.LastModified}>
                   {tag.last_modified}
@@ -240,7 +240,18 @@ export default function Table(props: TableProps) {
                             noPadding={childHasNoPadding}
                             colSpan={archColspan}
                           >
-                            <ExpandableRowContent>{`${manifest.platform.os} on ${manifest.platform.architecture}`}</ExpandableRowContent>
+                            <ExpandableRowContent>
+                              <Link
+                                to={getTagDetailPath(
+                                  props.organization,
+                                  props.repository,
+                                  tag.name,
+                                  manifest.platform.architecture,
+                                )}
+                              >
+                                {`${manifest.platform.os} on ${manifest.platform.architecture}`}
+                              </Link>
+                            </ExpandableRowContent>
                           </Td>
                         ) : (
                           <Td />

--- a/src/components/shared/Repository/Tabs/Tags/Table.tsx
+++ b/src/components/shared/Repository/Tabs/Tags/Table.tsx
@@ -19,6 +19,8 @@ import {Tag} from 'src/resources/TagResource';
 import SecurityDetails from './SecurityDetails';
 import {selectedTagsState} from 'src/atoms/TagListState';
 import {useRecoilState} from 'recoil';
+import {Link} from 'react-router-dom';
+import {getTagDetailPath, getDomain} from 'src/routes/NavigationPath';
 
 const columnNames = {
   Tag: 'Tag',
@@ -32,7 +34,6 @@ const columnNames = {
 };
 
 export default function Table(props: TableProps) {
-  const quayDomain = process.env.REACT_APP_QUAY_DOMAIN || 'quay.io';
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [modalImageTag, setModalImageTag] = useState<string>('');
   const [modalImageDigest, setModalImageDigest] = useState<string>('');
@@ -113,7 +114,7 @@ export default function Table(props: TableProps) {
           hoverTip="Copy"
           clickTip="Copied"
         >
-          docker pull {quayDomain}/{props.organization}/{props.repository}:
+          docker pull {getDomain()}/{props.organization}/{props.repository}:
           {modalImageTag}
         </ClipboardCopy>
         <br></br>
@@ -125,7 +126,7 @@ export default function Table(props: TableProps) {
           hoverTip="Copy"
           clickTip="Copied"
         >
-          docker pull {quayDomain}/{props.organization}/{props.repository}@
+          docker pull {getDomain()}/{props.organization}/{props.repository}@
           {modalImageDigest}
         </ClipboardCopy>
       </Modal>
@@ -184,7 +185,17 @@ export default function Table(props: TableProps) {
                     isSelected: selectedTags.includes(tag.name),
                   }}
                 />
-                <Td dataLabel={columnNames.Tag}>{tag.name}</Td>
+                <Td dataLabel={columnNames.Tag}>
+                  <Link
+                    to={getTagDetailPath(
+                      props.organization,
+                      props.repository,
+                      tag.name,
+                    )}
+                  >
+                    {tag.name}
+                  </Link>
+                </Td>
                 <Td dataLabel={columnNames.OS}>os-mock</Td>
                 <Td dataLabel={columnNames.Security}>
                   {typeof tag.manifest_list != 'undefined' ? (

--- a/src/components/shared/Repository/Tabs/Tags/Tags.test.tsx
+++ b/src/components/shared/Repository/Tabs/Tags/Tags.test.tsx
@@ -3,6 +3,7 @@ import {render, screen, fireEvent} from '@testing-library/react';
 import {RecoilRoot} from 'recoil';
 import {mocked} from 'ts-jest/utils';
 import {Tag, TagsResponse, getTags, deleteTag} from 'src/resources/TagResource';
+import {MemoryRouter} from 'react-router-dom';
 
 jest.mock('src/resources/TagResource', () => ({
   getTags: jest.fn(),
@@ -39,6 +40,7 @@ test('Tags should render', async () => {
     <RecoilRoot>
       <Tags organization={testOrg} repository={testRepo} />
     </RecoilRoot>,
+    {wrapper: MemoryRouter},
   );
   const message = await screen.findByText('This repository is empty.');
   expect(message).toBeTruthy();
@@ -52,6 +54,7 @@ test('Tags should appear in list', async () => {
     <RecoilRoot>
       <Tags organization={testOrg} repository={testRepo} />
     </RecoilRoot>,
+    {wrapper: MemoryRouter},
   );
   const message = await screen.findByText('latest');
   expect(message).toBeTruthy();
@@ -68,6 +71,7 @@ test('Filter search should return matching list', async () => {
     <RecoilRoot>
       <Tags organization={testOrg} repository={testRepo} />
     </RecoilRoot>,
+    {wrapper: MemoryRouter},
   );
   expect(await screen.findByText('latest')).toBeTruthy();
   expect(await screen.findByText('slim')).toBeTruthy();
@@ -89,6 +93,7 @@ test('Updating per page should update table content', async () => {
     <RecoilRoot>
       <Tags organization={testOrg} repository={testRepo} />
     </RecoilRoot>,
+    {wrapper: MemoryRouter},
   );
   const initialRows = await screen.findAllByTestId('table-entry');
   expect(initialRows.length).toBe(25);
@@ -117,6 +122,7 @@ test('Updating page should update table content', async () => {
     <RecoilRoot>
       <Tags organization={testOrg} repository={testRepo} />
     </RecoilRoot>,
+    {wrapper: MemoryRouter},
   );
   const initialRows = await screen.findAllByTestId('table-entry');
   expect(initialRows.length).toBe(25);
@@ -137,6 +143,7 @@ test('Copy modal should show org and repo', async () => {
     <RecoilRoot>
       <Tags organization={testOrg} repository={testRepo} />
     </RecoilRoot>,
+    {wrapper: MemoryRouter},
   );
   expect(await screen.findByText(tag.name)).toBeTruthy();
   fireEvent(
@@ -163,6 +170,7 @@ test('Delete a single tag', async () => {
     <RecoilRoot>
       <Tags organization={testOrg} repository={testRepo} />
     </RecoilRoot>,
+    {wrapper: MemoryRouter},
   );
   expect(await screen.findByText(tag.name)).toBeTruthy();
   const rowSelect = screen.getByLabelText('Select row 0', {selector: 'input'});
@@ -204,6 +212,7 @@ test('Delete a multiple tags', async () => {
     <RecoilRoot>
       <Tags organization={testOrg} repository={testRepo} />
     </RecoilRoot>,
+    {wrapper: MemoryRouter},
   );
   expect(await screen.findByText('latest')).toBeTruthy();
   expect(await screen.findByText('slim')).toBeTruthy();

--- a/src/resources/TagResource.ts
+++ b/src/resources/TagResource.ts
@@ -72,11 +72,14 @@ export async function getTags(
   repo: string,
   page: number,
   limit = 100,
+  specificTag = null,
 ) {
   try {
-    const response: AxiosResponse<TagsResponse> = await axios.get(
-      `/api/v1/repository/${org}/${repo}/tag/?limit=${limit}&page=${page}&onlyActiveTags=true`,
-    );
+    let path = `/api/v1/repository/${org}/${repo}/tag/?limit=${limit}&page=${page}&onlyActiveTags=true`;
+    if (specificTag) {
+      path = path.concat(`&specificTag=${specificTag}`);
+    }
+    const response: AxiosResponse<TagsResponse> = await axios.get(path);
     return response.data;
   } catch (error: any) {
     throw new Error(`API error getting tags ${error.message}`);

--- a/src/routes/NavigationPath.tsx
+++ b/src/routes/NavigationPath.tsx
@@ -13,4 +13,19 @@ export enum NavigationPath {
   // Repository detail
   repositoryDetail = '/repositories/:repositoryName',
   settings = '/organizations/:reponame/settings',
+
+  // Tag Detail
+  tagDetail = '/organizations/:organizationName/:repoName/:tagName',
+}
+
+export function getTagDetailPath(org: string, repo: string, tag: string) {
+  let tagPath = NavigationPath.tagDetail.toString();
+  tagPath = tagPath.replace(':organizationName', org);
+  tagPath = tagPath.replace(':repoName', repo);
+  tagPath = tagPath.replace(':tagName', tag);
+  return tagPath;
+}
+
+export function getDomain() {
+  return process.env.REACT_APP_QUAY_DOMAIN || 'quay.io';
 }

--- a/src/routes/NavigationPath.tsx
+++ b/src/routes/NavigationPath.tsx
@@ -18,11 +18,19 @@ export enum NavigationPath {
   tagDetail = '/organizations/:organizationName/:repoName/:tagName',
 }
 
-export function getTagDetailPath(org: string, repo: string, tag: string) {
+export function getTagDetailPath(
+  org: string,
+  repo: string,
+  tag: string,
+  arch = null,
+) {
   let tagPath = NavigationPath.tagDetail.toString();
   tagPath = tagPath.replace(':organizationName', org);
   tagPath = tagPath.replace(':repoName', repo);
   tagPath = tagPath.replace(':tagName', tag);
+  if (arch) {
+    tagPath = tagPath + `?arch=${arch}`;
+  }
   return tagPath;
 }
 

--- a/src/routes/StandaloneMain.tsx
+++ b/src/routes/StandaloneMain.tsx
@@ -13,6 +13,7 @@ import Organization from './OrganizationsList/Organization/Organization';
 import {NavigationPath} from './NavigationPath';
 import RepositoriesList from './RepositoriesList/RepositoriesList';
 import TagsList from '../components/shared/Repository/TagsList';
+import TagDetails from './TagDetails/TagDetails';
 
 export function StandaloneMain() {
   const [, setUserState] = useRecoilState(UserState);
@@ -41,6 +42,7 @@ export function StandaloneMain() {
           element={<Organization />}
         />
         <Route path={NavigationPath.repositoryDetail} element={<TagsList />} />
+        <Route path={NavigationPath.tagDetail} element={<TagDetails />} />
 
         <Route
           path={NavigationPath.repositoryDetailForOrg}

--- a/src/routes/TagDetails/Details.tsx
+++ b/src/routes/TagDetails/Details.tsx
@@ -1,0 +1,97 @@
+import {
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListGroup,
+  DescriptionListDescription,
+  Divider,
+  PageSection,
+  PageSectionVariants,
+  ClipboardCopy,
+} from '@patternfly/react-core';
+import CopyTags from './DetailsCopyTags';
+import {Tag} from 'src/resources/TagResource';
+
+export default function Details(props: DetailsProps) {
+  return (
+    <>
+      <PageSection variant={PageSectionVariants.light}>
+        <DescriptionList
+          columnModifier={{
+            default: '2Col',
+          }}
+        >
+          <DescriptionListGroup data-testid="name">
+            <DescriptionListTerm>Name</DescriptionListTerm>
+            <DescriptionListDescription>
+              {props.tag.name}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup data-testid="creation">
+            <DescriptionListTerm>Creation</DescriptionListTerm>
+            <DescriptionListDescription>
+              {props.tag.start_ts}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup data-testid="repository">
+            <DescriptionListTerm>Repository</DescriptionListTerm>
+            <DescriptionListDescription>
+              {props.repo}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup data-testid="modified">
+            <DescriptionListTerm>Modified</DescriptionListTerm>
+            <DescriptionListDescription>
+              {props.tag.last_modified}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Digest</DescriptionListTerm>
+            <DescriptionListDescription>
+              <ClipboardCopy
+                data-testid="digest-clipboardcopy"
+                isReadOnly
+                hoverTip="Copy"
+                clickTip="Copied"
+              >
+                {props.digest}
+              </ClipboardCopy>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup data-testid="size">
+            <DescriptionListTerm>Size</DescriptionListTerm>
+            <DescriptionListDescription>
+              {props.size}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup data-testid="vulnerabilities">
+            <DescriptionListTerm>Vulnerabilities</DescriptionListTerm>
+            <DescriptionListDescription>
+              TODO-vulernabilities
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup data-testid="labels">
+            <DescriptionListTerm>Labels</DescriptionListTerm>
+            <DescriptionListDescription>TODO-labels</DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
+      </PageSection>
+      <Divider />
+      <PageSection variant={PageSectionVariants.light}>
+        <CopyTags
+          org={props.org}
+          repo={props.repo}
+          tag={props.tag.name}
+          digest={props.digest}
+        />
+      </PageSection>
+    </>
+  );
+}
+
+type DetailsProps = {
+  tag: Tag;
+  org: string;
+  repo: string;
+  size: number;
+  digest: string;
+};

--- a/src/routes/TagDetails/Details.tsx
+++ b/src/routes/TagDetails/Details.tsx
@@ -29,7 +29,9 @@ export default function Details(props: DetailsProps) {
           <DescriptionListGroup data-testid="creation">
             <DescriptionListTerm>Creation</DescriptionListTerm>
             <DescriptionListDescription>
-              {props.tag.start_ts}
+              {new Date(props.tag.start_ts).toLocaleString('en-US', {
+                timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              })}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup data-testid="repository">

--- a/src/routes/TagDetails/DetailsCopyTags.tsx
+++ b/src/routes/TagDetails/DetailsCopyTags.tsx
@@ -1,0 +1,86 @@
+import {
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListGroup,
+  DescriptionListDescription,
+  ClipboardCopy,
+  Title,
+} from '@patternfly/react-core';
+import {getDomain} from 'src/routes/NavigationPath';
+
+export default function CopyTags(props: CopyTagsProps) {
+  return (
+    <>
+      <Title headingLevel="h3">Fetch Tag</Title>
+      <DescriptionList>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Podman Pull (by tag)</DescriptionListTerm>
+          <DescriptionListDescription>
+            <ClipboardCopy
+              data-testid="podman-tag-clipboardcopy"
+              isReadOnly
+              hoverTip="Copy"
+              clickTip="Copied"
+            >
+              {`podman pull ${getDomain()}/${props.org}/${props.repo}:${
+                props.tag
+              }`}
+            </ClipboardCopy>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Docker Pull (by tag)</DescriptionListTerm>
+          <DescriptionListDescription>
+            <ClipboardCopy
+              data-testid="docker-tag-clipboardcopy"
+              isReadOnly
+              hoverTip="Copy"
+              clickTip="Copied"
+            >
+              {`docker pull ${getDomain()}/${props.org}/${props.repo}:${
+                props.tag
+              }`}
+            </ClipboardCopy>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Podman Pull (by digest)</DescriptionListTerm>
+          <DescriptionListDescription>
+            <ClipboardCopy
+              data-testid="podman-digest-clipboardcopy"
+              isReadOnly
+              hoverTip="Copy"
+              clickTip="Copied"
+            >
+              {`podman pull ${getDomain()}/${props.org}/${props.repo}@${
+                props.digest
+              }`}
+            </ClipboardCopy>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Docker Pull (by digest)</DescriptionListTerm>
+          <DescriptionListDescription>
+            <ClipboardCopy
+              data-testid="docker-digest-clipboardcopy"
+              isReadOnly
+              hoverTip="Copy"
+              clickTip="Copied"
+            >
+              {`docker pull ${getDomain()}/${props.org}/${props.repo}@${
+                props.digest
+              }`}
+            </ClipboardCopy>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+    </>
+  );
+}
+
+type CopyTagsProps = {
+  org: string;
+  repo: string;
+  tag: string;
+  digest: string;
+};

--- a/src/routes/TagDetails/TagDetails.test.tsx
+++ b/src/routes/TagDetails/TagDetails.test.tsx
@@ -1,0 +1,317 @@
+import {render, screen, fireEvent} from '@testing-library/react';
+import {within} from '@testing-library/dom';
+import {RecoilRoot} from 'recoil';
+import {useLocation, useNavigate, useSearchParams} from 'react-router-dom';
+import {mocked} from 'ts-jest/utils';
+import TagDetails from './TagDetails';
+import {
+  Tag,
+  TagsResponse,
+  getTags,
+  getManifestByDigest,
+  Manifest,
+} from 'src/resources/TagResource';
+
+jest.mock('react-router-dom', () => ({
+  useLocation: jest.fn(),
+  useNavigate: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock('src/resources/TagResource', () => ({
+  getTags: jest.fn(),
+  getManifestByDigest: jest.fn(),
+  getSecurityDetails: jest.fn(),
+  deleteTag: jest.fn(),
+}));
+
+const createTagResponse = (): TagsResponse => {
+  return {
+    page: 1,
+    has_additional: false,
+    tags: [],
+  };
+};
+const createTag = (name = 'latest'): Tag => {
+  return {
+    name: name,
+    is_manifest_list: false,
+    last_modified: 'Thu, 02 Jun 2022 19:12:32 -0000',
+    size: 100,
+    manifest_digest: 'sha256:fd0922d',
+    reversion: false,
+    start_ts: 1654197152,
+    manifest_list: null,
+  };
+};
+
+type Test = {
+  testId: string;
+  name?: string;
+  value: string | number;
+};
+
+const checkFieldValues = async (tests: Test[]) => {
+  for (const test of tests) {
+    const field = screen.getByTestId(test.testId);
+    expect(within(field).getByText(test.name)).toBeTruthy();
+    expect(await within(field).findByText(test.value)).toBeTruthy();
+  }
+};
+
+const checkClipboardValues = async (tests: Test[]) => {
+  for (const test of tests) {
+    const clipboardCopy = (
+      await screen.findByTestId(test.testId)
+    ).querySelector('input');
+    expect(clipboardCopy.value).toBe(test.value);
+  }
+};
+
+test('Render simple tag', async () => {
+  const mockResponse = createTagResponse();
+  const mockTag = createTag();
+  mockResponse.tags.push(mockTag);
+  mocked(getTags, true).mockResolvedValue(mockResponse);
+  mocked(useLocation, true).mockImplementation(() => ({
+    ...jest.requireActual('react-router-dom').useLocation,
+    pathname: '/organizations/testorg/testrepo/latest',
+  }));
+  mocked(useSearchParams, true).mockImplementation(() => [
+    new URLSearchParams(),
+    jest.fn(),
+  ]);
+  render(
+    <RecoilRoot>
+      <TagDetails />
+    </RecoilRoot>,
+  );
+  const tests: Test[] = [
+    {
+      testId: 'name',
+      name: 'Name',
+      value: mockTag.name,
+    },
+    {
+      testId: 'creation',
+      name: 'Creation',
+      value: mockTag.start_ts,
+    },
+    {
+      testId: 'repository',
+      name: 'Repository',
+      value: 'testrepo',
+    },
+    {
+      testId: 'modified',
+      name: 'Modified',
+      value: mockTag.last_modified,
+    },
+    {
+      testId: 'size',
+      name: 'Size',
+      value: mockTag.size,
+    },
+    {
+      testId: 'vulnerabilities',
+      name: 'Vulnerabilities',
+      value: 'TODO-vulernabilities',
+    },
+    {
+      testId: 'labels',
+      name: 'Labels',
+      value: 'TODO-labels',
+    },
+  ];
+  await checkFieldValues(tests);
+  const clipboardCopyTests: Test[] = [
+    {
+      testId: 'digest-clipboardcopy',
+      value: mockTag.manifest_digest,
+    },
+    {
+      testId: 'podman-tag-clipboardcopy',
+      value: 'podman pull quay.io/testorg/testrepo:latest',
+    },
+    {
+      testId: 'docker-tag-clipboardcopy',
+      value: 'docker pull quay.io/testorg/testrepo:latest',
+    },
+    {
+      testId: 'podman-digest-clipboardcopy',
+      value: 'podman pull quay.io/testorg/testrepo@' + mockTag.manifest_digest,
+    },
+    {
+      testId: 'docker-digest-clipboardcopy',
+      value: 'docker pull quay.io/testorg/testrepo@' + mockTag.manifest_digest,
+    },
+  ];
+  await checkClipboardValues(clipboardCopyTests);
+});
+
+test('Render manifest list tag', async () => {
+  const mockResponse = createTagResponse();
+  const mockTag = createTag();
+  mockTag.is_manifest_list = true;
+  mockResponse.tags.push(mockTag);
+
+  const FIRST_MANIFEST = 0,
+    SECOND_MANIFEST = 1;
+  const mockManifest = {
+    schemaVersion: 2,
+    mediaType: 'application/vnd.oci.image.index.v1+json',
+    manifests: [
+      {
+        digest: 'sha256:abcdefghijk',
+        size: 1,
+        platform: {
+          architecture: 'ppc64le',
+          os: 'linux',
+        },
+      },
+      {
+        digest: 'sha256:12345678910',
+        size: 2,
+        platform: {
+          architecture: 'amd64',
+          os: 'linux',
+        },
+      },
+    ],
+  };
+
+  mocked(getTags, true).mockResolvedValue(mockResponse);
+  mocked(getManifestByDigest, true).mockResolvedValue({
+    digest: mockTag.manifest_digest,
+    is_manifest_list: true,
+    manifest_data: JSON.stringify(mockManifest),
+  });
+  mocked(useLocation, true).mockImplementation(() => ({
+    ...jest.requireActual('react-router-dom').useLocation,
+    pathname: '/organizations/testorg/testrepo/latest',
+  }));
+  mocked(useSearchParams, true).mockImplementation(() => [
+    new URLSearchParams(),
+    jest.fn(),
+  ]);
+
+  render(
+    <RecoilRoot>
+      <TagDetails />
+    </RecoilRoot>,
+  );
+
+  const archSelect = await screen.findByText('ppc64le');
+  expect(archSelect).toBeTruthy();
+
+  const tests: Test[] = [
+    {
+      testId: 'name',
+      name: 'Name',
+      value: mockTag.name,
+    },
+    {
+      testId: 'creation',
+      name: 'Creation',
+      value: mockTag.start_ts,
+    },
+    {
+      testId: 'repository',
+      name: 'Repository',
+      value: 'testrepo',
+    },
+    {
+      testId: 'modified',
+      name: 'Modified',
+      value: mockTag.last_modified,
+    },
+    {
+      testId: 'size',
+      name: 'Size',
+      value: mockManifest.manifests[FIRST_MANIFEST].size,
+    },
+    {
+      testId: 'vulnerabilities',
+      name: 'Vulnerabilities',
+      value: 'TODO-vulernabilities',
+    },
+    {
+      testId: 'labels',
+      name: 'Labels',
+      value: 'TODO-labels',
+    },
+  ];
+  await checkFieldValues(tests);
+
+  let clipboardCopyTests: Test[] = [
+    {
+      testId: 'digest-clipboardcopy',
+      value: mockManifest.manifests[FIRST_MANIFEST].digest,
+    },
+    {
+      testId: 'podman-tag-clipboardcopy',
+      value: 'podman pull quay.io/testorg/testrepo:latest',
+    },
+    {
+      testId: 'docker-tag-clipboardcopy',
+      value: 'docker pull quay.io/testorg/testrepo:latest',
+    },
+    {
+      testId: 'podman-digest-clipboardcopy',
+      value:
+        'podman pull quay.io/testorg/testrepo@' +
+        mockManifest.manifests[FIRST_MANIFEST].digest,
+    },
+    {
+      testId: 'docker-digest-clipboardcopy',
+      value:
+        'docker pull quay.io/testorg/testrepo@' +
+        mockManifest.manifests[FIRST_MANIFEST].digest,
+    },
+  ];
+  await checkClipboardValues(clipboardCopyTests);
+
+  // Select the other architecture
+  fireEvent(
+    archSelect,
+    new MouseEvent('click', {bubbles: true, cancelable: true}),
+  );
+  expect(await screen.findAllByText('ppc64le')).toBeTruthy();
+  const secondArchOption = await screen.findByText('amd64');
+  expect(secondArchOption).toBeTruthy();
+  fireEvent(
+    secondArchOption,
+    new MouseEvent('click', {bubbles: true, cancelable: true}),
+  );
+
+  tests[4].value = mockManifest.manifests[SECOND_MANIFEST].size;
+  await checkFieldValues(tests);
+
+  clipboardCopyTests = [
+    {
+      testId: 'digest-clipboardcopy',
+      value: mockManifest.manifests[SECOND_MANIFEST].digest,
+    },
+    {
+      testId: 'podman-tag-clipboardcopy',
+      value: 'podman pull quay.io/testorg/testrepo:latest',
+    },
+    {
+      testId: 'docker-tag-clipboardcopy',
+      value: 'docker pull quay.io/testorg/testrepo:latest',
+    },
+    {
+      testId: 'podman-digest-clipboardcopy',
+      value:
+        'podman pull quay.io/testorg/testrepo@' +
+        mockManifest.manifests[SECOND_MANIFEST].digest,
+    },
+    {
+      testId: 'docker-digest-clipboardcopy',
+      value:
+        'docker pull quay.io/testorg/testrepo@' +
+        mockManifest.manifests[SECOND_MANIFEST].digest,
+    },
+  ];
+  await checkClipboardValues(clipboardCopyTests);
+});

--- a/src/routes/TagDetails/TagDetails.test.tsx
+++ b/src/routes/TagDetails/TagDetails.test.tsx
@@ -95,7 +95,9 @@ test('Render simple tag', async () => {
     {
       testId: 'creation',
       name: 'Creation',
-      value: mockTag.start_ts,
+      value: new Date(mockTag.start_ts).toLocaleString('en-US', {
+        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }),
     },
     {
       testId: 'repository',
@@ -213,7 +215,9 @@ test('Render manifest list tag', async () => {
     {
       testId: 'creation',
       name: 'Creation',
-      value: mockTag.start_ts,
+      value: new Date(mockTag.start_ts).toLocaleString('en-US', {
+        timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }),
     },
     {
       testId: 'repository',

--- a/src/routes/TagDetails/TagDetails.tsx
+++ b/src/routes/TagDetails/TagDetails.tsx
@@ -7,7 +7,7 @@ import {
   Title,
   PageBreadcrumb,
 } from '@patternfly/react-core';
-import {useLocation} from 'react-router-dom';
+import {useSearchParams, useLocation} from 'react-router-dom';
 import {useState, useEffect} from 'react';
 import TagArchSelect from './TagDetailsArchSelect';
 import TagTabs from './TagDetailsTabs';
@@ -21,6 +21,7 @@ import {
 } from 'src/resources/TagResource';
 
 export default function TagDetails() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [architecture, setArchitecture] = useState<string>();
   const [tagDetails, setTagDetails] = useState<Tag>({
     name: '',
@@ -71,7 +72,9 @@ export default function TagDetails() {
 
         setTagDetails(tagResp);
         if (archs.length > 0) {
-          setArchitecture(archs[0]);
+          setArchitecture(
+            searchParams.get('arch') ? searchParams.get('arch') : archs[0],
+          );
         }
       } catch (error: any) {
         // TODO: provide sufficient error handling, will be resolved in a future PR

--- a/src/routes/TagDetails/TagDetails.tsx
+++ b/src/routes/TagDetails/TagDetails.tsx
@@ -1,0 +1,134 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Page,
+  PageSection,
+  PageSectionVariants,
+  Title,
+  PageBreadcrumb,
+} from '@patternfly/react-core';
+import {useLocation} from 'react-router-dom';
+import {useState, useEffect} from 'react';
+import TagArchSelect from './TagDetailsArchSelect';
+import TagTabs from './TagDetailsTabs';
+import {
+  TagsResponse,
+  getTags,
+  getManifestByDigest,
+  Tag,
+  ManifestByDigestResponse,
+  Manifest,
+} from 'src/resources/TagResource';
+
+export default function TagDetails() {
+  const [architecture, setArchitecture] = useState<string>();
+  const [tagDetails, setTagDetails] = useState<Tag>({
+    name: '',
+    is_manifest_list: false,
+    last_modified: '',
+    manifest_digest: '',
+    reversion: false,
+    size: 0,
+    start_ts: 0,
+    manifest_list: {
+      schemaVersion: 0,
+      mediaType: '',
+      manifests: [],
+    },
+  });
+
+  // TODO: refactor, need more checks when parsing path
+  const location = useLocation();
+  const [org, ...repoPath] = location.pathname.split('/').slice(2);
+  const tag = repoPath.pop();
+  const repo = repoPath.join('/');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const resp: TagsResponse = await getTags(org, repo, 1, 100, tag);
+
+        // These should never happen but checking for errors just in case
+        if (resp.tags.length === 0) {
+          throw new Error('Could not find tag');
+        }
+        if (resp.tags.length > 1) {
+          throw new Error(
+            'Unexpected response from API: more than one tag returned',
+          );
+        }
+
+        const tagResp: Tag = resp.tags[0];
+        const archs: string[] = [];
+        if (tagResp.is_manifest_list) {
+          const manifestResp: ManifestByDigestResponse =
+            await getManifestByDigest(org, repo, tagResp.manifest_digest);
+          tagResp.manifest_list = JSON.parse(manifestResp.manifest_data);
+          for (const manifest of tagResp.manifest_list.manifests) {
+            archs.push(manifest.platform.architecture);
+          }
+        }
+
+        setTagDetails(tagResp);
+        if (archs.length > 0) {
+          setArchitecture(archs[0]);
+        }
+      } catch (error: any) {
+        // TODO: provide sufficient error handling, will be resolved in a future PR
+        console.log('error');
+        console.log(error);
+      }
+    })();
+  }, []);
+
+  // Pull size and digest from manifest otherwise default to pull from tagDetails
+  let size: number = tagDetails.size;
+  let digest: string = tagDetails.manifest_digest;
+  if (architecture) {
+    const manifest: Manifest = tagDetails.manifest_list?.manifests.filter(
+      (manifest: Manifest) => manifest.platform.architecture === architecture,
+    )[0];
+    size = manifest.size;
+    digest = manifest.digest;
+  }
+
+  return (
+    <Page>
+      {/* TODO: replace this with generic breadcrumb in future PR */}
+      <PageBreadcrumb>
+        <Breadcrumb>
+          <BreadcrumbItem data-testid="namespace-breadcrumb" to="#">
+            organizations
+          </BreadcrumbItem>
+          <BreadcrumbItem data-testid="org-breadcrumb" to="#">
+            {org}
+          </BreadcrumbItem>
+          <BreadcrumbItem data-testid="repo-breadcrumb" to="#">
+            {repo}
+          </BreadcrumbItem>
+          <BreadcrumbItem data-testid="tag-breadcrumb" to="#">
+            {tag}
+          </BreadcrumbItem>
+        </Breadcrumb>
+      </PageBreadcrumb>
+      <PageSection variant={PageSectionVariants.light}>
+        <Title headingLevel="h1">{tag}</Title>
+        <TagArchSelect
+          arch={architecture}
+          options={tagDetails.manifest_list?.manifests.map(
+            (manifest: Manifest) => manifest.platform.architecture,
+          )}
+          setArch={setArchitecture}
+          render={tagDetails.is_manifest_list}
+        />
+        <TagTabs
+          org={org}
+          repo={repo}
+          tag={tagDetails}
+          size={size}
+          digest={digest}
+        />
+      </PageSection>
+    </Page>
+  );
+}

--- a/src/routes/TagDetails/TagDetailsArchSelect.tsx
+++ b/src/routes/TagDetails/TagDetailsArchSelect.tsx
@@ -1,0 +1,47 @@
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import {useState} from 'react';
+
+export default function ArchSelect(props: ArchSelectProps) {
+  if (!props.render) return null;
+  const [isSelectOpen, setIsSelectOpen] = useState<boolean>();
+
+  return (
+    <Flex>
+      <FlexItem>Architecture</FlexItem>
+      <FlexItem>
+        <Select
+          variant={SelectVariant.single}
+          placeholderText="Architecture"
+          aria-label="Architecture select"
+          onToggle={() => {
+            setIsSelectOpen(!isSelectOpen);
+          }}
+          onSelect={(e, arch) => {
+            props.setArch(arch as string);
+            setIsSelectOpen(false);
+          }}
+          selections={props.arch}
+          isOpen={isSelectOpen}
+          data-testid="arch-select"
+        >
+          {props.options.map((arch, index) => (
+            <SelectOption key={index} value={arch} />
+          ))}
+        </Select>
+      </FlexItem>
+    </Flex>
+  );
+}
+
+type ArchSelectProps = {
+  arch: string;
+  options: string[];
+  setArch: (arch: string) => void;
+  render: boolean;
+};

--- a/src/routes/TagDetails/TagDetailsTabs.tsx
+++ b/src/routes/TagDetails/TagDetailsTabs.tsx
@@ -1,0 +1,61 @@
+import {Tabs, Tab, TabTitleText} from '@patternfly/react-core';
+import {useSearchParams, useNavigate} from 'react-router-dom';
+import {useState} from 'react';
+import Details from './Details';
+import {Tag} from 'src/resources/TagResource';
+
+enum TabIndex {
+  Details = 'details',
+  Layers = 'layers',
+  SecurityReport = 'securityreport',
+  Packages = 'packages',
+}
+
+// Return the tab as an enum or null if it does not exist
+function getTabIndex(tab: string) {
+  if (Object.values(TabIndex).includes(tab as TabIndex)) {
+    return tab as TabIndex;
+  }
+}
+
+export default function TagTabs(props: TagTabsProps) {
+  const [activeTabKey, setActiveTabKey] = useState<TabIndex>(TabIndex.Details);
+  const navigate = useNavigate();
+
+  // Navigate to the correct tab
+  const [searchParams, setSearchParams] = useSearchParams();
+  const requestedTabIndex = getTabIndex(searchParams.get('tab'));
+  if (requestedTabIndex && requestedTabIndex !== activeTabKey) {
+    setActiveTabKey(requestedTabIndex);
+  }
+
+  return (
+    <Tabs
+      activeKey={activeTabKey}
+      onSelect={(e, tabIndex) => {
+        navigate(`${location.pathname}?tab=${tabIndex}`);
+      }}
+    >
+      <Tab
+        eventKey={TabIndex.Details}
+        title={<TabTitleText>Details</TabTitleText>}
+      >
+        <Details
+          org={props.org}
+          repo={props.repo}
+          tag={props.tag}
+          size={props.size}
+          digest={props.digest}
+        ></Details>
+      </Tab>
+    </Tabs>
+  );
+}
+
+type TagTabsProps = {
+  tag: Tag;
+  org: string;
+  repo: string;
+  size: number;
+  digest: string;
+};

--- a/src/tests/fake-db/ApiMock.ts
+++ b/src/tests/fake-db/ApiMock.ts
@@ -3,5 +3,8 @@ import {mock} from './MockAxios';
 import './data/login/login';
 import './data/user/user';
 import './data/repository/repository';
+import './data/tag/tag';
+import './data/security/security';
+import './data/tag/manifest';
 
 mock.onAny().passThrough();

--- a/src/tests/fake-db/data/security/security.ts
+++ b/src/tests/fake-db/data/security/security.ts
@@ -1,0 +1,23 @@
+import {mock} from 'src/tests/fake-db/MockAxios';
+import {SecurityDetailsResponse} from 'src/resources/TagResource';
+
+const securityResponse: SecurityDetailsResponse = {
+  status: 'queued',
+  data: {
+    Layer: {
+      Name: '',
+      ParentName: '',
+      NamespaceName: '',
+      IndexedByVersion: 1,
+      Features: [],
+    },
+  },
+};
+
+mock
+  .onGet(
+    /api\/v1\/repository\/testorg\/testrepo\/manifest\/.+\/security\?vulnerabilities=true/,
+  )
+  .reply(() => {
+    return [200, securityResponse];
+  });

--- a/src/tests/fake-db/data/tag/manifest.ts
+++ b/src/tests/fake-db/data/tag/manifest.ts
@@ -1,0 +1,42 @@
+import {mock} from 'src/tests/fake-db/MockAxios';
+import {AxiosRequestConfig} from 'axios';
+import {ManifestByDigestResponse, Manifest} from 'src/resources/TagResource';
+
+const manifest = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.oci.image.index.v1+json',
+  manifests: [
+    {
+      digest:
+        'sha256:3a8221b6b7780a7d5211f826dd35a24e31eadb507111deae66b0cfea7c52a824',
+      size: 1000,
+      platform: {
+        architecture: 'ppc64le',
+        os: 'linux',
+      },
+    },
+    {
+      digest:
+        'sha256:6854f4ba26f34d1029d481024d3e03d87aaa2635389e6e38d8557e69184546f1',
+      size: 2000,
+      platform: {
+        architecture: 'amd64',
+        os: 'linux',
+      },
+    },
+  ],
+};
+
+mock
+  .onGet(/api\/v1\/repository\/testorg\/testrepo\/manifest\/.+/)
+  .reply((request: AxiosRequestConfig) => {
+    const manifestResponse: ManifestByDigestResponse = {
+      digest: '',
+      manifest_data: '',
+      is_manifest_list: true,
+    };
+    const digest = request.baseURL.split('/').pop();
+    manifestResponse.digest = digest;
+    manifestResponse.manifest_data = JSON.stringify(manifest);
+    return [200, manifestResponse];
+  });

--- a/src/tests/fake-db/data/tag/tag.ts
+++ b/src/tests/fake-db/data/tag/tag.ts
@@ -1,0 +1,67 @@
+import {mock} from 'src/tests/fake-db/MockAxios';
+import {AxiosRequestConfig} from 'axios';
+import {TagsResponse, Tag} from 'src/resources/TagResource';
+
+const testTag: Tag = {
+  name: 'testtag',
+  is_manifest_list: false,
+  last_modified: 'Thu, 02 Jun 2022 19:12:32 -0000',
+  size: 100,
+  manifest_digest:
+    'sha256:ad6562704f3759fb50f0d3de5f80a38f65a85e709b77fd24491253990f30b6be',
+  reversion: false,
+  start_ts: 1654197152,
+  manifest_list: null,
+};
+
+const manifestListTag: Tag = {
+  name: 'manifestlist',
+  is_manifest_list: true,
+  last_modified: 'Thu, 02 Jun 2022 19:12:32 -0000',
+  size: 100,
+  manifest_digest:
+    'sha256:ad6562704f3759fb50f0d3de5f80a38f65a85e709b77fd24491253990f30b6be',
+  reversion: false,
+  start_ts: 1654197152,
+  manifest_list: {
+    schemaVersion: 2,
+    mediaType: '',
+    manifests: [],
+  },
+};
+
+mock
+  .onGet(
+    /api\/v1\/repository\/testorg\/testrepo\/tag\/\?limit=100&page=1&onlyActiveTags=true&specificTag=.+/,
+  )
+  .reply((request: AxiosRequestConfig) => {
+    const tagResponse: TagsResponse = {
+      page: 1,
+      has_additional: false,
+      tags: [],
+    };
+    const searchParams = new URLSearchParams(request.url);
+    switch (searchParams.get('specificTag')) {
+      case 'testtag':
+        tagResponse.tags.push(testTag);
+        break;
+      case 'manifestlist':
+        tagResponse.tags.push(manifestListTag);
+    }
+    return [200, tagResponse];
+  });
+
+mock
+  .onGet(
+    '/api/v1/repository/testorg/testrepo/tag/?limit=100&page=1&onlyActiveTags=true',
+  )
+  .reply(() => {
+    const tagResponse: TagsResponse = {
+      page: 1,
+      has_additional: false,
+      tags: [],
+    };
+    tagResponse.tags.push(testTag);
+    tagResponse.tags.push(manifestListTag);
+    return [200, tagResponse];
+  });


### PR DESCRIPTION
Made the following changes:
- Added page to view details about a particular tag
- Manifest list tags can switch between architectures
- Taglist table now links to tag detailspage
- TagResource now accepts specificName parameter to get details for a single tag
- NavigationPath now has helper methods for getting domain and constructing tagdetails path

Running locally:
Run with `MOCK_API=true npm start` and go to the `organizations/testorg/testrepo` page. Selecting a tag there will go to the tag details page.