### PR TITLE
Fix link when navigating from repo list to a repo

### DIFF
--- a/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -386,7 +386,15 @@ export default function RepositoriesList() {
                   }}
                 />
                 <Td dataLabel={columnNames.repoName}>
-                  <Link to={repo.name}>{repo.name}</Link>
+                  {currentOrg == null ? (
+                    <Link to={`${repo.namespace}/${repo.name}`}>
+                      {repo.namespace}/{repo.name}
+                    </Link>
+                  ) : (
+                    <Link to={`${repo.namespace}/${repo.name}`}>
+                      {repo.name}
+                    </Link>
+                  )}
                 </Td>
                 <Td dataLabel={columnNames.visibility}>
                   {' '}


### PR DESCRIPTION
When going to a repo from the `Repositories` sidebar the URL is not correctly updated causing tag list to fail
![image](https://user-images.githubusercontent.com/55854/179248667-b9a1fe73-7a2a-454f-9162-c29abc64420b.png)
