### PR TITLE
Building Breadcrumbs by keeping track of browser history (PROJQUAY-4090)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,22 +25,18 @@
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.0",
         "recoil": "^0.7.0",
+        "recoil-persist": "^4.2.0",
         "ts-jest": "^26.5.6",
         "typescript": "^4.6.3",
         "use-react-router-breadcrumbs": "^3.2.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "@babel/core": "^7.17.9",
-        "@babel/preset-env": "^7.16.11",
-        "@babel/preset-react": "^7.16.7",
-        "@babel/preset-typescript": "^7.16.7",
         "@types/react-dom": "^17.0.2",
         "@types/react-router-dom": "^5.3.3",
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.18.0",
         "axios-mock-adapter": "^1.20.0",
-        "babel-loader": "^8.2.5",
         "copy-webpack-plugin": "^10.2.4",
         "css-loader": "^6.7.1",
         "css-minimizer-webpack-plugin": "^3.4.1",
@@ -22357,6 +22353,14 @@
         }
       }
     },
+    "node_modules/recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -44317,6 +44321,12 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
+    },
+    "recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "requires": {}
     },
     "recursive-readdir": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.0",
     "recoil": "^0.7.0",
+    "recoil-persist": "^4.2.0",
     "ts-jest": "^26.5.6",
     "typescript": "^4.6.3",
     "use-react-router-breadcrumbs": "^3.2.1",

--- a/src/atoms/BrowserHistoryState.ts
+++ b/src/atoms/BrowserHistoryState.ts
@@ -1,6 +1,10 @@
 import {atom} from 'recoil';
+import {recoilPersist} from 'recoil-persist';
+
+const {persistAtom} = recoilPersist();
 
 export const BrowserHistoryState = atom({
   key: 'browserHistoryState',
-  default: new Set(),
+  default: [],
+  effects_UNSTABLE: [persistAtom],
 });

--- a/src/atoms/BrowserHistoryState.ts
+++ b/src/atoms/BrowserHistoryState.ts
@@ -1,0 +1,6 @@
+import {atom} from 'recoil';
+
+export const BrowserHistoryState = atom({
+  key: 'browserHistoryState',
+  default: new Set(),
+});

--- a/src/components/breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb.tsx
@@ -3,6 +3,7 @@ import {
   BreadcrumbItem,
   PageBreadcrumb,
 } from '@patternfly/react-core';
+import {NavigationRoutes} from 'src/routes/NavigationPath';
 import {Link} from 'react-router-dom';
 import React, {useEffect, useState} from 'react';
 import useBreadcrumbs from 'use-react-router-breadcrumbs';
@@ -12,17 +13,24 @@ export function QuayBreadcrumb() {
   const [breadcrumbItems, setBreadcrumbItems] = useState<QuayBreadcrumbItem[]>(
     [],
   );
-  const routerBreadcrumbs: BreadcrumbData[] = useBreadcrumbs();
+  const routerBreadcrumbs: BreadcrumbData[] = useBreadcrumbs(NavigationRoutes, {
+    disableDefaults: true,
+    excludePaths: ['/'],
+  });
 
   useEffect(() => {
     const result = [];
+    console.log('routerBreadcrumbs', routerBreadcrumbs);
     routerBreadcrumbs.map((object, i) => {
-      if (object.match.pathname == '/') {
-        return;
-      }
       const newObj = {};
       newObj['pathname'] = object.match.pathname;
-      newObj['title'] = object.breadcrumb.props.children;
+      if (object.breadcrumb.props.children) {
+        newObj['title'] = object.breadcrumb.props.children;
+      } else {
+        console.log('object.match', object.match);
+        console.log('object.match.route', object.match.route);
+        newObj['title'] = object.match.route.breadcrumb(object.match);
+      }
       newObj['active'] =
         object.match.pathname.localeCompare(window.location.pathname) === 0;
       result.push(newObj);

--- a/src/components/breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb.tsx
@@ -73,14 +73,18 @@ export function QuayBreadcrumb() {
 
     for (const value of Array.from(browserHistory.values())) {
       const newObj = {};
-      newObj['pathname'] = value.pathname;
-      if (typeof value.title === 'string') {
-        newObj['title'] = value.title;
-      } else if (value.title?.props?.children) {
-        newObj['title'] = value.title.props.children;
+      newObj['pathname'] = value['pathname'];
+      if (typeof value['title'] === 'string') {
+        newObj['title'] = value['title'];
+      } else if (
+        value['title'] &&
+        value['title']['props'] &&
+        value['title']['props']['children']
+      ) {
+        newObj['title'] = value['title']['props']['children'];
       }
       newObj['active'] =
-        value.pathname.localeCompare(window.location.pathname) === 0;
+        value['pathname'].localeCompare(window.location.pathname) === 0;
       if (newItem['pathname'] == newObj['pathname']) {
         newItem['title'] = newObj['title'];
         break;
@@ -159,6 +163,7 @@ type BreadcrumbMatch = {
 
 type BreadcrumbsRoute = {
   breadcrumb?: BreadcrumbComponentType | any | null;
+  Component?: React.ReactElement | any;
 };
 
 type RouterBreadcrumbDetail = {

--- a/src/components/breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb.tsx
@@ -28,12 +28,12 @@ export function QuayBreadcrumb() {
 
   const resetBreadCrumbs = () => {
     setBreadcrumbItems([]);
-    setBrowserHistoryState(new Set());
+    setBrowserHistoryState([]);
   };
 
   const buildFromRoute = () => {
     const result = [];
-    const history = new Set();
+    const history = [];
     routerBreadcrumbs.map((object, i) => {
       const newObj = {};
       newObj['pathname'] = object.match.pathname;
@@ -45,7 +45,7 @@ export function QuayBreadcrumb() {
       newObj['active'] =
         object.match.pathname.localeCompare(window.location.pathname) === 0;
       result.push(newObj);
-      history.add(newObj);
+      history.push(newObj);
     });
     setBreadcrumbItems(result);
     setBrowserHistoryState(history);
@@ -68,7 +68,7 @@ export function QuayBreadcrumb() {
 
   const buildFromBrowserHistory = () => {
     const result = [];
-    const history = new Set();
+    const history = [];
     const newItem = currentBreadcrumbItem();
 
     for (const value of Array.from(browserHistory.values())) {
@@ -90,10 +90,10 @@ export function QuayBreadcrumb() {
         break;
       }
       result.push(newObj);
-      history.add(newObj);
+      history.push(newObj);
     }
     result.push(newItem);
-    history.add(newItem);
+    history.push(newItem);
 
     setBreadcrumbItems(result);
     setBrowserHistoryState(history);
@@ -107,7 +107,7 @@ export function QuayBreadcrumb() {
       return;
     }
 
-    if (browserHistory.size > 0) {
+    if (browserHistory.length > 0) {
       buildFromBrowserHistory();
     } else {
       buildFromRoute();

--- a/src/components/breadcrumb/Breadcrumb.tsx
+++ b/src/components/breadcrumb/Breadcrumb.tsx
@@ -6,7 +6,9 @@ import {
 import {NavigationRoutes} from 'src/routes/NavigationPath';
 import {Link} from 'react-router-dom';
 import React, {useEffect, useState} from 'react';
-import useBreadcrumbs from 'use-react-router-breadcrumbs';
+import useBreadcrumbs, {
+  BreadcrumbComponentType,
+} from 'use-react-router-breadcrumbs';
 import {useLocation} from 'react-router';
 
 export function QuayBreadcrumb() {
@@ -20,15 +22,12 @@ export function QuayBreadcrumb() {
 
   useEffect(() => {
     const result = [];
-    console.log('routerBreadcrumbs', routerBreadcrumbs);
     routerBreadcrumbs.map((object, i) => {
       const newObj = {};
       newObj['pathname'] = object.match.pathname;
       if (object.breadcrumb.props.children) {
         newObj['title'] = object.breadcrumb.props.children;
       } else {
-        console.log('object.match', object.match);
-        console.log('object.match.route', object.match.route);
         newObj['title'] = object.match.route.breadcrumb(object.match);
       }
       newObj['active'] =
@@ -76,6 +75,11 @@ type BreadcrumbData = {
 
 type BreadcrumbMatch = {
   pathname: string;
+  route?: BreadcrumbsRoute;
+};
+
+type BreadcrumbsRoute = {
+  breadcrumb?: BreadcrumbComponentType | any | null;
 };
 
 type RouterBreadcrumbDetail = {

--- a/src/routes/NavigationPath.tsx
+++ b/src/routes/NavigationPath.tsx
@@ -1,7 +1,34 @@
+import OrganizationsList from 'src/routes/OrganizationsList/OrganizationsList';
+import Organization from './OrganizationsList/Organization/Organization';
+import RepositoryDetails from 'src/routes/RepositoryDetails/RepositoryDetails';
+import RepositoriesList from './RepositoriesList/RepositoriesList';
+import TagDetails from 'src/routes/TagDetails/TagDetails';
+
+const organizationNameBreadcrumb = (match) => {
+  return <span>{match.params.organizationName}</span>;
+};
+
+const repositoryNameBreadcrumb = (match) => {
+  return <span>{match.params.repositoryName}</span>;
+};
+
+const tagNameBreadcrumb = (match) => {
+  return <span>{match.params.tagName}</span>;
+};
+
+const Breadcrumb = {
+  organizationsListBreadcrumb: 'Organizations',
+  repositoriesListBreadcrumb: 'Repositories',
+  organizationDetailBreadcrumb: organizationNameBreadcrumb,
+  repositoryDetailBreadcrumb: repositoryNameBreadcrumb,
+  tagDetailBreadcrumb: tagNameBreadcrumb,
+};
+
 export enum NavigationPath {
   // Side Nav
   home = '/',
   organizationsList = '/organizations',
+
   repositoriesList = '/repositories',
 
   // Organization detail
@@ -44,3 +71,32 @@ export function getTagDetailPath(
 export function getDomain() {
   return process.env.REACT_APP_QUAY_DOMAIN || 'quay.io';
 }
+
+const NavigationRoutes = [
+  {
+    path: NavigationPath.organizationsList,
+    Component: <OrganizationsList />,
+    breadcrumb: 'organizations',
+  },
+  {
+    path: NavigationPath.organizationDetail,
+    Component: <Organization />,
+    breadcrumb: Breadcrumb.organizationDetailBreadcrumb,
+  },
+  {
+    path: NavigationPath.repositoriesList,
+    Component: <RepositoriesList />,
+    breadcrumb: Breadcrumb.repositoriesListBreadcrumb,
+  },
+  {
+    path: NavigationPath.repositoryDetail,
+    Component: <RepositoryDetails />,
+    breadcrumb: Breadcrumb.repositoryDetailBreadcrumb,
+  },
+  {
+    path: NavigationPath.tagDetail,
+    Component: <TagDetails />,
+    breadcrumb: Breadcrumb.tagDetailBreadcrumb,
+  },
+];
+export {NavigationRoutes};

--- a/src/routes/OrganizationsList/OrganizationsList.tsx
+++ b/src/routes/OrganizationsList/OrganizationsList.tsx
@@ -28,6 +28,7 @@ import {OrganizationToolBar} from './OrganizationToolBar';
 import {CubesIcon} from '@patternfly/react-icons';
 import {ToolbarButton} from 'src/components/toolbar/ToolbarButton';
 import Empty from 'src/components/empty/Empty';
+import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
 
 // Attempt to render OrganizationsList content,
 // fallback to RequestError on failure
@@ -263,6 +264,7 @@ function PageContent() {
 
   return (
     <Page>
+      <QuayBreadcrumb />
       <PageSection variant={PageSectionVariants.light}>
         <OrganizationToolBar
           createOrgModal={createOrgModal}

--- a/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -29,7 +29,6 @@ import {getRepoDetailPath} from 'src/routes/NavigationPath';
 import {selectedReposState, filterRepoState} from 'src/atoms/RepositoryState';
 import {formatDate} from 'src/libs/utils';
 import {BulkDeleteModalTemplate} from 'src/components/modals/BulkDeleteModalTemplate';
-import {getUser} from 'src/resources/UserResource';
 import {RepositoryToolBar} from 'src/routes/RepositoriesList/RepositoryToolBar';
 import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
 import ErrorBoundary from 'src/components/errors/ErrorBoundary';
@@ -38,6 +37,7 @@ import RequestError from 'src/components/errors/RequestError';
 import Empty from 'src/components/empty/Empty';
 import {CubesIcon} from '@patternfly/react-icons';
 import {ToolbarButton} from 'src/components/toolbar/ToolbarButton';
+import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
 
 function getReponameFromURL(pathname: string): string {
   return pathname.includes('organizations') ? pathname.split('/')[2] : null;
@@ -63,11 +63,14 @@ export default function RepositoriesList() {
 
 function RepoListTitle() {
   return (
-    <PageSection variant={PageSectionVariants.light} hasShadowBottom>
-      <div className="co-m-nav-title--row">
-        <Title headingLevel="h1">Repositories</Title>
-      </div>
-    </PageSection>
+    <div>
+      <QuayBreadcrumb />
+      <PageSection variant={PageSectionVariants.light} hasShadowBottom>
+        <div className="co-m-nav-title--row">
+          <Title headingLevel="h1">Repositories</Title>
+        </div>
+      </PageSection>
+    </div>
   );
 }
 

--- a/src/routes/TagDetails/TagDetails.tsx
+++ b/src/routes/TagDetails/TagDetails.tsx
@@ -20,6 +20,7 @@ import {
   Manifest,
 } from 'src/resources/TagResource';
 import {addDisplayError} from 'src/resources/ErrorHandling';
+import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
 
 export default function TagDetails() {
   const [searchParams] = useSearchParams();
@@ -98,23 +99,7 @@ export default function TagDetails() {
 
   return (
     <Page>
-      {/* TODO: replace this with generic breadcrumb in future PR */}
-      <PageBreadcrumb>
-        <Breadcrumb>
-          <BreadcrumbItem data-testid="namespace-breadcrumb" to="#">
-            organizations
-          </BreadcrumbItem>
-          <BreadcrumbItem data-testid="org-breadcrumb" to="#">
-            {org}
-          </BreadcrumbItem>
-          <BreadcrumbItem data-testid="repo-breadcrumb" to="#">
-            {repo}
-          </BreadcrumbItem>
-          <BreadcrumbItem data-testid="tag-breadcrumb" to="#">
-            {tag}
-          </BreadcrumbItem>
-        </Breadcrumb>
-      </PageBreadcrumb>
+      <QuayBreadcrumb />
       <PageSection variant={PageSectionVariants.light}>
         <Title headingLevel="h1">{tag}</Title>
         <TagArchSelect


### PR DESCRIPTION
Breadcrumbs are generated by two ways:

1. From url route
2. From Browser history

If the browser history is empty, breadcrumbs will be generated from the url route. If browser history exists, breadcrumbs are generated from this history. `BrowserHistoryState` tracks users history on the application. 