### PR TITLE
Automatically remove console.*  (PROJQUAY-4195)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "sass": "^1.50.0",
         "style-loader": "^3.3.1",
         "svg-url-loader": "^7.1.1",
+        "terser-webpack-plugin": "^5.3.3",
         "ts-loader": "^9.3.0",
         "ts-node": "^10.7.0",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
@@ -3801,9 +3802,9 @@
       "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -24706,14 +24707,14 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
-      "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
       "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.7",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1",
         "terser": "^5.7.2"
       },
       "engines": {
@@ -30291,9 +30292,9 @@
       "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
-      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+      "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -46171,14 +46172,14 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
-      "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
       "requires": {
+        "@jridgewell/trace-mapping": "^0.3.7",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1",
         "terser": "^5.7.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "sass": "^1.50.0",
     "style-loader": "^3.3.1",
     "svg-url-loader": "^7.1.1",
+    "terser-webpack-plugin": "^5.3.3",
     "ts-loader": "^9.3.0",
     "ts-node": "^10.7.0",
     "tsconfig-paths-webpack-plugin": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -47,16 +47,11 @@
     ]
   },
   "devDependencies": {
-    "@babel/core": "^7.17.9",
-    "@babel/preset-env": "^7.16.11",
-    "@babel/preset-react": "^7.16.7",
-    "@babel/preset-typescript": "^7.16.7",
     "@types/react-dom": "^17.0.2",
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
     "axios-mock-adapter": "^1.20.0",
-    "babel-loader": "^8.2.5",
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "^6.7.1",
     "css-minimizer-webpack-plugin": "^3.4.1",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,8 +1,8 @@
 /* eslint-env node */
 
-import { Configuration as WebpackConfiguration } from "webpack";
-import { Configuration as WebpackDevServerConfiguration } from "webpack-dev-server";
-import * as path from "path";
+import {Configuration as WebpackConfiguration} from 'webpack';
+import {Configuration as WebpackDevServerConfiguration} from 'webpack-dev-server';
+import * as path from 'path';
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 // import { ConsoleRemotePlugin } from "@openshift-console/dynamic-plugin-sdk-webpack";
@@ -13,61 +13,44 @@ interface Configuration extends WebpackConfiguration {
 }
 
 const config: Configuration = {
-  mode: "development",
+  mode: 'development',
   // No regular entry points. The remote container entry is handled by ConsoleRemotePlugin.
   // entry: {},
   entry: path.resolve(__dirname, './src/index.tsx'),
-  context: path.resolve(__dirname, "src"),
+  context: path.resolve(__dirname, 'src'),
   output: {
-    path: path.resolve(__dirname, "dist"),
-    filename: "[name]-bundle.js",
-    chunkFilename: "[name]-chunk.js",
+    path: path.resolve(__dirname, 'dist'),
+    filename: '[name]-bundle.js',
+    chunkFilename: '[name]-chunk.js',
   },
   resolve: {
-    extensions: [".ts", ".tsx", ".js", ".jsx"],
+    extensions: ['.ts', '.tsx', '.js', '.jsx'],
   },
   module: {
     rules: [
-      // {
-      //   test: /\.(jsx?|tsx?)$/,
-      //   exclude: /node_modules/,
-      //   use: [
-      //     {
-      //       loader: "ts-loader",
-      //       options: {
-      //         configFile: path.resolve(__dirname, "tsconfig.json"),
-      //       },
-      //     },
-      //   ],
-      // },
-      {
-        test: /\.(jsx?|tsx?)$/,
-        exclude: /node_modules/,
-        use: "babel-loader"
-      },
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        use: ['style-loader', 'css-loader'],
       },
       {
         test: /\.scss$/,
         exclude: /node_modules/,
         use: [
-            {
-                loader: 'style-loader',
+          {
+            loader: 'style-loader',
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: true,
             },
-            {
-                loader: 'css-loader',
-                options: {
-                    sourceMap: true,
-                },
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true,
             },
-            {
-                loader: 'sass-loader',
-                options: {
-                    sourceMap: true,
-                },
-            },
+          },
         ],
       },
       {
@@ -92,9 +75,10 @@ const config: Configuration = {
     // Allow bridge running in a container to connect to the plugin dev server.
     allowedHosts: 'all',
     headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
-      "Access-Control-Allow-Headers": "X-Requested-With, Content-Type, Authorization"
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
+      'Access-Control-Allow-Headers':
+        'X-Requested-With, Content-Type, Authorization',
     },
     devMiddleware: {
       writeToDisk: true,
@@ -103,24 +87,24 @@ const config: Configuration = {
   plugins: [
     // new ConsoleRemotePlugin(),
     new HtmlWebpackPlugin({
-      template: path.join(__dirname, "public", "index.html")
+      template: path.join(__dirname, 'public', 'index.html'),
     }),
     new CopyWebpackPlugin({
-      patterns: [{ from: path.resolve(__dirname, 'locales'), to: 'locales' }],
+      patterns: [{from: path.resolve(__dirname, 'locales'), to: 'locales'}],
     }),
   ],
-  devtool: "source-map",
+  devtool: 'source-map',
   optimization: {
-    chunkIds: "named",
+    chunkIds: 'named',
     minimize: false,
   },
 };
 
-if (process.env.NODE_ENV === "production") {
-  config.mode = "production";
-  config.output.filename = "[name]-bundle-[hash].min.js";
-  config.output.chunkFilename = "[name]-chunk-[chunkhash].min.js";
-  config.optimization.chunkIds = "deterministic";
+if (process.env.NODE_ENV === 'production') {
+  config.mode = 'production';
+  config.output.filename = '[name]-bundle-[hash].min.js';
+  config.output.chunkFilename = '[name]-chunk-[chunkhash].min.js';
+  config.optimization.chunkIds = 'deterministic';
   config.optimization.minimize = true;
 }
 

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -13,7 +13,13 @@ module.exports = merge(common('production'), {
   devtool: 'source-map',
   optimization: {
     minimizer: [
-      new TerserJSPlugin({}),
+      new TerserJSPlugin({
+        terserOptions: {
+          compress: {
+            pure_funcs: ['console.log', 'console.debug'],
+          },
+        },
+      }),
       new CssMinimizerPlugin({
         minimizerOptions: {
           preset: ['default', { mergeLonghand: false }],


### PR DESCRIPTION
* Removes `console.log` and `console.debug` from prod builds

This can be validated by building and running the local production build in a docker container and checking the console at signin:
```
docker build -t quay-ui:local .
docker run -d --name quay-ui -p 9000:9000 quay-ui:local
```

Old:
<img width="836" alt="image" src="https://user-images.githubusercontent.com/1656866/180458428-c98a1531-f4dd-4c34-a0bf-3e45f3b8878d.png">

New: 
<img width="887" alt="image" src="https://user-images.githubusercontent.com/1656866/180458095-04582a9d-19b8-4208-8f2d-dc1540f80c9e.png">


