### PR TITLE
Use loading page while waiting on security report (PROJQUAY-4152)

### DIFF
--- a/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -8,6 +8,7 @@ import {
   Page,
   PageSection,
   PageSectionVariants,
+  Spinner,
   TextInput,
   Title,
   Toolbar,
@@ -375,42 +376,51 @@ export default function RepositoriesList() {
             </Tr>
           </Thead>
           <Tbody>
-            {repositoryList.map((repo, rowIndex) => (
-              <Tr key={rowIndex}>
-                <Td
-                  select={{
-                    rowIndex,
-                    onSelect: (_event, isSelecting) =>
-                      onSelectRepo(repo, rowIndex, isSelecting),
-                    isSelected: isRepoSelected(repo),
-                    disable: !isRepoSelectable(repo),
-                  }}
-                />
-                <Td dataLabel={columnNames.repoName}>
-                  {currentOrg == null ? (
-                    <Link to={getRepoDetailPath(repo.namespace, repo.name)}>
-                      {repo.namespace}/{repo.name}
-                    </Link>
-                  ) : (
-                    <Link to={getRepoDetailPath(repo.namespace, repo.name)}>
-                      {repo.name}
-                    </Link>
-                  )}
-                </Td>
-                <Td dataLabel={columnNames.visibility}>
-                  {' '}
-                  {repo.isPublic ? 'public' : 'private'}
-                </Td>
-                <Td dataLabel={columnNames.tags}> {repo.tags} </Td>
-                <Td dataLabel={columnNames.size}> {repo.size} </Td>
-                <Td dataLabel={columnNames.pulls}> {repo.pulls} </Td>
-                <Td dataLabel={columnNames.lastPull}> {repo.lastPull} </Td>
-                <Td dataLabel={columnNames.lastModified}>
-                  {' '}
-                  {repo.lastModified}{' '}
+            {repositoryList.length === 0 ? (
+              // Repo table loading icon
+              <Tr>
+                <Td>
+                  <Spinner size="lg" />
                 </Td>
               </Tr>
-            ))}
+            ) : (
+              repositoryList.map((repo, rowIndex) => (
+                <Tr key={rowIndex}>
+                  <Td
+                    select={{
+                      rowIndex,
+                      onSelect: (_event, isSelecting) =>
+                        onSelectRepo(repo, rowIndex, isSelecting),
+                      isSelected: isRepoSelected(repo),
+                      disable: !isRepoSelectable(repo),
+                    }}
+                  />
+                  <Td dataLabel={columnNames.repoName}>
+                    {currentOrg == null ? (
+                      <Link to={getRepoDetailPath(repo.namespace, repo.name)}>
+                        {repo.namespace}/{repo.name}
+                      </Link>
+                    ) : (
+                      <Link to={getRepoDetailPath(repo.namespace, repo.name)}>
+                        {repo.name}
+                      </Link>
+                    )}
+                  </Td>
+                  <Td dataLabel={columnNames.visibility}>
+                    {' '}
+                    {repo.isPublic ? 'public' : 'private'}
+                  </Td>
+                  <Td dataLabel={columnNames.tags}> {repo.tags} </Td>
+                  <Td dataLabel={columnNames.size}> {repo.size} </Td>
+                  <Td dataLabel={columnNames.pulls}> {repo.pulls} </Td>
+                  <Td dataLabel={columnNames.lastPull}> {repo.lastPull} </Td>
+                  <Td dataLabel={columnNames.lastModified}>
+                    {' '}
+                    {repo.lastModified}{' '}
+                  </Td>
+                </Tr>
+              ))
+            )}
           </Tbody>
         </TableComposable>
       </PageSection>

--- a/src/routes/RepositoryDetails/Tags/SecurityDetails.tsx
+++ b/src/routes/RepositoryDetails/Tags/SecurityDetails.tsx
@@ -1,3 +1,4 @@
+import {Skeleton, Spinner} from '@patternfly/react-core';
 import {useEffect, useState} from 'react';
 import {
   SecurityDetailsResponse,
@@ -9,17 +10,21 @@ import {TabIndex} from 'src/routes/TagDetails/TagDetailsTabs';
 
 export default function SecurityDetails(props: SecurityDetailsProps) {
   const [status, setStatus] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    (async () => {
-      try {
-        const securityDetails: SecurityDetailsResponse =
-          await getSecurityDetails(props.org, props.repo, props.digest);
-        setStatus(securityDetails.status);
-      } catch (error: any) {
-        console.log('Unable to get security details: ', error);
-      }
-    })();
+    if (props.digest !== '') {
+      (async () => {
+        try {
+          const securityDetails: SecurityDetailsResponse =
+            await getSecurityDetails(props.org, props.repo, props.digest);
+          setStatus(securityDetails.status);
+          setIsLoading(false);
+        } catch (error: any) {
+          console.log('Unable to get security details: ', error);
+        }
+      })();
+    }
   }, []);
   const queryParams = new Map<string, string>([
     ['tab', TabIndex.SecurityReport],
@@ -27,6 +32,12 @@ export default function SecurityDetails(props: SecurityDetailsProps) {
   if (props.arch) {
     queryParams.set('arch', props.arch);
   }
+
+  // Loading icon for security details in security column
+  if (isLoading) {
+    return <Skeleton width="50%"></Skeleton>;
+  }
+
   return (
     <Link to={getTagDetailPath(props.org, props.repo, props.tag, queryParams)}>
       {status}

--- a/src/routes/RepositoryDetails/Tags/Table.tsx
+++ b/src/routes/RepositoryDetails/Tags/Table.tsx
@@ -1,3 +1,4 @@
+import {Spinner} from '@patternfly/react-core';
 import {
   ExpandableRowContent,
   TableComposable,
@@ -232,7 +233,9 @@ export default function Table(props: TableProps) {
           />
         ))}
       </TableComposable>
-      {props.tags.length == 0 ? <div>This repository is empty.</div> : null}
+
+      {/* Loading icon for table without tag data */}
+      {props.tags.length == 0 ? <Spinner isSVG size="lg" /> : null}
     </>
   );
 }

--- a/src/routes/TagDetails/Details/Details.tsx
+++ b/src/routes/TagDetails/Details/Details.tsx
@@ -7,6 +7,7 @@ import {
   PageSection,
   PageSectionVariants,
   ClipboardCopy,
+  Skeleton,
 } from '@patternfly/react-core';
 import prettyBytes from 'pretty-bytes';
 import CopyTags from './DetailsCopyTags';
@@ -26,57 +27,85 @@ export default function Details(props: DetailsProps) {
           <DescriptionListGroup data-testid="name">
             <DescriptionListTerm>Name</DescriptionListTerm>
             <DescriptionListDescription>
-              {props.tag.name}
+              {props.tag.name ? (
+                props.tag.name
+              ) : (
+                <Skeleton width="100%"></Skeleton>
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup data-testid="creation">
             <DescriptionListTerm>Creation</DescriptionListTerm>
             <DescriptionListDescription>
-              {formatDate(props.tag.start_ts)}
+              {props.tag.start_ts ? (
+                formatDate(props.tag.start_ts)
+              ) : (
+                <Skeleton width="100%"></Skeleton>
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup data-testid="repository">
             <DescriptionListTerm>Repository</DescriptionListTerm>
             <DescriptionListDescription>
-              {props.repo}
+              {props.repo ? props.repo : <Skeleton width="100%"></Skeleton>}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup data-testid="modified">
             <DescriptionListTerm>Modified</DescriptionListTerm>
             <DescriptionListDescription>
-              {formatDate(props.tag.last_modified)}
+              {props.tag.last_modified ? (
+                formatDate(props.tag.last_modified)
+              ) : (
+                <Skeleton width="100%"></Skeleton>
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Digest</DescriptionListTerm>
             <DescriptionListDescription>
-              <ClipboardCopy
-                data-testid="digest-clipboardcopy"
-                isReadOnly
-                hoverTip="Copy"
-                clickTip="Copied"
-                variant="inline-compact"
-              >
-                {props.digest}
-              </ClipboardCopy>
+              {props.digest ? (
+                <ClipboardCopy
+                  data-testid="digest-clipboardcopy"
+                  isReadOnly
+                  hoverTip="Copy"
+                  clickTip="Copied"
+                  variant="inline-compact"
+                >
+                  {props.digest}
+                </ClipboardCopy>
+              ) : (
+                <Skeleton width="100%"></Skeleton>
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup data-testid="size">
             <DescriptionListTerm>Size</DescriptionListTerm>
             <DescriptionListDescription>
-              {prettyBytes(props.size)}
+              {props.size ? (
+                prettyBytes(props.size)
+              ) : (
+                <Skeleton width="100%"></Skeleton>
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup data-testid="vulnerabilities">
             <DescriptionListTerm>Vulnerabilities</DescriptionListTerm>
             <DescriptionListDescription>
-              TODO-vulernabilities
+              {/* TODO - vulernabilities */}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup data-testid="labels">
             <DescriptionListTerm>Labels</DescriptionListTerm>
             <DescriptionListDescription>
-              <Labels org={props.org} repo={props.repo} digest={props.digest} />
+              {props.digest !== '' ? (
+                <Labels
+                  org={props.org}
+                  repo={props.repo}
+                  digest={props.digest}
+                />
+              ) : (
+                <Skeleton width="100%"></Skeleton>
+              )}
             </DescriptionListDescription>
           </DescriptionListGroup>
         </DescriptionList>

--- a/src/routes/TagDetails/Packages/Packages.tsx
+++ b/src/routes/TagDetails/Packages/Packages.tsx
@@ -11,15 +11,17 @@ export function Packages(props: PackagesProps) {
   const [data, setData] = useState<Data>(null);
 
   useEffect(() => {
-    (async () => {
-      try {
-        const securityDetails: SecurityDetailsResponse =
-          await getSecurityDetails(props.org, props.repo, props.digest);
-        setData(securityDetails.data);
-      } catch (error) {
-        console.error('Unable to get security details: ', error);
-      }
-    })();
+    if (props.digest !== '') {
+      (async () => {
+        try {
+          const securityDetails: SecurityDetailsResponse =
+            await getSecurityDetails(props.org, props.repo, props.digest);
+          setData(securityDetails.data);
+        } catch (error) {
+          console.error('Unable to get security details: ', error);
+        }
+      })();
+    }
   }, []);
 
   if (data) {

--- a/src/routes/TagDetails/SecurityReport/SecurityReport.tsx
+++ b/src/routes/TagDetails/SecurityReport/SecurityReport.tsx
@@ -6,32 +6,39 @@ import {
   SecurityDetailsResponse,
 } from 'src/resources/TagResource';
 import {SecurityReportChart} from './SecurityReportChart';
+import {LoadingPage} from 'src/components/LoadingPage';
 
 export default function SecurityReport(props: SecurityReportProps) {
   const [data, setData] = useState<Data>(null);
+
+  // Grab security details based on digest
   useEffect(() => {
-    (async () => {
-      try {
-        const securityDetails: SecurityDetailsResponse =
-          await getSecurityDetails(props.org, props.repo, props.digest);
-        setData(securityDetails.data);
-      } catch (error) {
-        console.error('Unable to get security details: ', error);
-      }
-    })();
-  }, []);
+    if (props.digest !== '') {
+      (async () => {
+        try {
+          const securityDetails: SecurityDetailsResponse =
+            await getSecurityDetails(props.org, props.repo, props.digest);
+          setData(securityDetails.data);
+        } catch (error) {
+          console.error('Unable to get security details: ', error);
+        }
+      })();
+    }
+  }, [props.digest]);
+
+  let features = [];
 
   if (data) {
-    return (
-      <>
-        <SecurityReportChart features={data.Layer.Features} />
-        <hr />
-        <SecurityReportTable features={data.Layer.Features} />
-      </>
-    );
+    features = data.Layer.Features;
   }
 
-  return <div>Loading</div>;
+  return (
+    <>
+      <SecurityReportChart features={features} />
+      <hr />
+      <SecurityReportTable features={features} />
+    </>
+  );
 }
 
 interface SecurityReportProps {

--- a/src/routes/TagDetails/SecurityReport/SecurityReportChart.tsx
+++ b/src/routes/TagDetails/SecurityReport/SecurityReportChart.tsx
@@ -4,6 +4,7 @@ import {ChartDonut} from '@patternfly/react-charts';
 import {
   PageSection,
   PageSectionVariants,
+  Skeleton,
   Split,
   SplitItem,
   Title,
@@ -22,12 +23,19 @@ function VulnerabilitySummary(props: VulnerabilityStatsProps) {
           size={TitleSizes['3xl']}
           className="pf-u-mb-sm"
         >
-          Quay Security Reporting has detected {props.total} vulnerabilities
+          {props.total ? (
+            `Quay Security Reporting has detected ${props.total} vulnerabilities`
+          ) : (
+            <Skeleton width="400px" />
+          )}
         </Title>
         <Title headingLevel="h3" className="pf-u-mb-lg">
-          Patches are available for {props.patchesAvailable} vulnerabilities
+          {props.total ? (
+            `Patches are available for ${props.patchesAvailable} vulnerabilities`
+          ) : (
+            <Skeleton width="300px" />
+          )}
         </Title>
-
         {Object.keys(props.stats).map((vulnLevel) => {
           if (props.stats[vulnLevel] > 0) {
             return (
@@ -50,29 +58,33 @@ function VulnerabilitySummary(props: VulnerabilityStatsProps) {
 function VulnerabilityChart(props: VulnerabilityStatsProps) {
   return (
     <div style={{height: '20em', width: '20em'}}>
-      <ChartDonut
-        ariaDesc="vulnerability chart"
-        ariaTitle="vulnerability chart"
-        constrainToVisibleArea={true}
-        data={[
-          {x: VulnerabilitySeverity.Critical, y: props.stats.Critical},
-          {x: VulnerabilitySeverity.High, y: props.stats.High},
-          {x: VulnerabilitySeverity.Medium, y: props.stats.Medium},
-          {x: VulnerabilitySeverity.Low, y: props.stats.Low},
-          {x: VulnerabilitySeverity.Negligible, y: props.stats.Negligible},
-          {x: VulnerabilitySeverity.Unknown, y: props.stats.Unknown},
-        ]}
-        colorScale={[
-          getSeverityColor(VulnerabilitySeverity.Critical),
-          getSeverityColor(VulnerabilitySeverity.High),
-          getSeverityColor(VulnerabilitySeverity.Medium),
-          getSeverityColor(VulnerabilitySeverity.Low),
-          getSeverityColor(VulnerabilitySeverity.Negligible),
-          getSeverityColor(VulnerabilitySeverity.Unknown),
-        ]}
-        labels={({datum}) => `${datum.x}: ${datum.y}`}
-        title={`${props.total}`}
-      />
+      {props.total !== 0 ? (
+        <ChartDonut
+          ariaDesc="vulnerability chart"
+          ariaTitle="vulnerability chart"
+          constrainToVisibleArea={true}
+          data={[
+            {x: VulnerabilitySeverity.Critical, y: props.stats.Critical},
+            {x: VulnerabilitySeverity.High, y: props.stats.High},
+            {x: VulnerabilitySeverity.Medium, y: props.stats.Medium},
+            {x: VulnerabilitySeverity.Low, y: props.stats.Low},
+            {x: VulnerabilitySeverity.Negligible, y: props.stats.Negligible},
+            {x: VulnerabilitySeverity.Unknown, y: props.stats.Unknown},
+          ]}
+          colorScale={[
+            getSeverityColor(VulnerabilitySeverity.Critical),
+            getSeverityColor(VulnerabilitySeverity.High),
+            getSeverityColor(VulnerabilitySeverity.Medium),
+            getSeverityColor(VulnerabilitySeverity.Low),
+            getSeverityColor(VulnerabilitySeverity.Negligible),
+            getSeverityColor(VulnerabilitySeverity.Unknown),
+          ]}
+          labels={({datum}) => `${datum.x}: ${datum.y}`}
+          title={`${props.total}`}
+        />
+      ) : (
+        <Skeleton shape="circle" width="100%" />
+      )}
     </div>
   );
 }

--- a/src/routes/TagDetails/SecurityReport/SecurityReportTable.tsx
+++ b/src/routes/TagDetails/SecurityReport/SecurityReportTable.tsx
@@ -11,7 +11,12 @@ import {
   ExpandableRowContent,
 } from '@patternfly/react-table';
 import {SecurityReportMetadataTable} from './SecurityReportMetadataTable';
-import {PageSection, PageSectionVariants, Title} from '@patternfly/react-core';
+import {
+  PageSection,
+  PageSectionVariants,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
 import {useRecoilState} from 'recoil';
 import {
   filteredVulnListState,
@@ -120,7 +125,7 @@ export default function SecurityReportTable({features}: SecurityDetailsProps) {
       <SecurityReportFilter />
       <TableComposable aria-label="Expandable table" variant={'compact'}>
         <TableHead />
-        {filteredVulnList ? (
+        {filteredVulnList.length !== 0 ? (
           filteredVulnList.map(
             (vulnerability: VulnerabilityListItem, rowIndex) => {
               const uniqueKey = generateUniqueKey(vulnerability);
@@ -201,11 +206,13 @@ export default function SecurityReportTable({features}: SecurityDetailsProps) {
             },
           )
         ) : (
-          <tbody>
-            <tr>
-              <td> Loading </td>
-            </tr>
-          </tbody>
+          <Tbody>
+            <Tr>
+              <Td>
+                <Spinner size="lg" />
+              </Td>
+            </Tr>
+          </Tbody>
         )}
       </TableComposable>
     </PageSection>

--- a/src/routes/TagDetails/TagDetails.tsx
+++ b/src/routes/TagDetails/TagDetails.tsx
@@ -24,7 +24,6 @@ import {
 export default function TagDetails() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [architecture, setArchitecture] = useState<string>();
-  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [tagDetails, setTagDetails] = useState<Tag>({
     name: '',
     is_manifest_list: false,
@@ -78,14 +77,13 @@ export default function TagDetails() {
             searchParams.get('arch') ? searchParams.get('arch') : archs[0],
           );
         }
-        setIsLoading(false);
       } catch (error: any) {
         // TODO: provide sufficient error handling, will be resolved in a future PR
         console.log('error');
         console.log(error);
       }
     })();
-  }, []);
+  }, [getTags, tagDetails.size]);
 
   // Pull size and digest from manifest otherwise default to pull from tagDetails
   let size: number = tagDetails.size;
@@ -96,10 +94,6 @@ export default function TagDetails() {
     )[0];
     size = manifest.size;
     digest = manifest.digest;
-  }
-
-  if (isLoading) {
-    return <Spinner isSVG />;
   }
 
   return (


### PR DESCRIPTION
* Adds Spinners to tables to indicate loading
* Adds Skeleton to Tag table cells to indicate loading
* Adds Skeleton to Tag Details and Security Report pages. 

This can best be tested by throttling the network connection using either Firefox and [GPRS throttling](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/throttling/index.html) or Chrome and [url-throttler](https://chrome.google.com/webstore/detail/url-throttler/kpkeghonflnkockcnaegmphgdldfnden)