### PR TITLE
Add skeleton to packages page (PROJQUAY-4243)

### DIFF
--- a/src/atoms/SecurityDetailsState.ts
+++ b/src/atoms/SecurityDetailsState.ts
@@ -1,0 +1,7 @@
+import {atom} from 'recoil';
+import {SecurityDetailsResponse} from 'src/resources/TagResource';
+
+export const SecurityDetailsState = atom<SecurityDetailsResponse>({
+  key: 'securityDetailsState',
+  default: null,
+});

--- a/src/routes/RepositoryDetails/Tags/Table.tsx
+++ b/src/routes/RepositoryDetails/Tags/Table.tsx
@@ -12,12 +12,13 @@ import prettyBytes from 'pretty-bytes';
 import {useState} from 'react';
 import {Tag, Manifest} from 'src/resources/TagResource';
 import {selectedTagsState} from 'src/atoms/TagListState';
-import {useRecoilState} from 'recoil';
+import {useRecoilState, useResetRecoilState} from 'recoil';
 import {Link} from 'react-router-dom';
 import {getTagDetailPath} from 'src/routes/NavigationPath';
 import TablePopover from './TablePopover';
 import SecurityDetails from './SecurityDetails';
 import {formatDate} from 'src/libs/utils';
+import {SecurityDetailsState} from 'src/atoms/SecurityDetailsState';
 
 const columnNames = {
   Tag: 'Tag',
@@ -88,6 +89,11 @@ function SubRow(props: SubRowProps) {
 function Row(props: RowProps) {
   const tag = props.tag;
   const rowIndex = props.rowIndex;
+
+  // Reset SecurityDetailsState so that loading skeletons appear when viewing report
+  const emptySecurityDetails = useResetRecoilState(SecurityDetailsState);
+  const resetSecurityDetails = () => emptySecurityDetails();
+
   return (
     <Tbody
       data-testid="table-entry"
@@ -116,7 +122,10 @@ function Row(props: RowProps) {
           }}
         />
         <Td dataLabel={columnNames.Tag}>
-          <Link to={getTagDetailPath(props.org, props.repo, tag.name)}>
+          <Link
+            to={getTagDetailPath(props.org, props.repo, tag.name)}
+            onClick={resetSecurityDetails}
+          >
             {tag.name}
           </Link>
         </Td>

--- a/src/routes/TagDetails/Packages/Packages.tsx
+++ b/src/routes/TagDetails/Packages/Packages.tsx
@@ -1,40 +1,25 @@
-import {
-  Data,
-  getSecurityDetails,
-  SecurityDetailsResponse,
-} from 'src/resources/TagResource';
 import {PackagesChart} from './PackagesChart';
-import {useEffect, useState} from 'react';
 import PackagesTable from './PackagesTable';
+import {useRecoilState} from 'recoil';
+import {SecurityDetailsState} from 'src/atoms/SecurityDetailsState';
 
 export function Packages(props: PackagesProps) {
-  const [data, setData] = useState<Data>(null);
+  const [data, setData] = useRecoilState(SecurityDetailsState);
 
-  useEffect(() => {
-    if (props.digest !== '') {
-      (async () => {
-        try {
-          const securityDetails: SecurityDetailsResponse =
-            await getSecurityDetails(props.org, props.repo, props.digest);
-          setData(securityDetails.data);
-        } catch (error) {
-          console.error('Unable to get security details: ', error);
-        }
-      })();
-    }
-  }, [props.digest]);
+  // Set features to a default of null to distinguish between a completed API call and one that is in progress
+  let features = null;
 
   if (data) {
-    return (
-      <>
-        <PackagesChart features={data.Layer.Features} />
-        <hr />
-        <PackagesTable features={data.Layer.Features} />
-      </>
-    );
+    features = data.data.Layer.Features;
   }
 
-  return <div>Loading</div>;
+  return (
+    <>
+      <PackagesChart features={features} />
+      <hr />
+      <PackagesTable features={features} />
+    </>
+  );
 }
 
 interface PackagesProps {

--- a/src/routes/TagDetails/Packages/PackagesChart.tsx
+++ b/src/routes/TagDetails/Packages/PackagesChart.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-
 import {ChartDonut} from '@patternfly/react-charts';
 import {
   PageSection,
   PageSectionVariants,
+  Skeleton,
   Split,
   SplitItem,
   Title,
@@ -22,6 +21,24 @@ function PackageMessage(props: PackageMessageProps) {
 }
 
 function PackagesSummary(props: PackageStatsProps) {
+  let packagesMessage = <Skeleton width="400px" />;
+  let availableMessage = <Skeleton width="300px" />;
+
+  // Check if API call has completed and if packages are found
+  if (props.stats[VulnerabilitySeverity.None] > 0 && props.total === 0) {
+    packagesMessage = (
+      <> Quay Security Reporting does not recognize any packages </>
+    );
+    availableMessage = <> No known patches are available </>;
+  } else if (props.total > 0) {
+    packagesMessage = (
+      <> Quay Security Reporting has recognized {props.total} packages </>
+    );
+    availableMessage = (
+      <> Patches are available for {props.patchesAvailable} vulnerabilities </>
+    );
+  }
+
   return (
     <div>
       <div className="pf-u-mt-xl pf-u-ml-2xl">
@@ -30,24 +47,29 @@ function PackagesSummary(props: PackageStatsProps) {
           size={TitleSizes['3xl']}
           className="pf-u-mb-sm"
         >
-          Quay Security Reporting has recognized {props.total} packages
+          {packagesMessage}
         </Title>
         <Title headingLevel="h3" className="pf-u-mb-lg">
-          Patches are available for {props.patchesAvailable} vulnerabilities
+          {availableMessage}
         </Title>
 
         {Object.keys(props.stats).map((vulnLevel) => {
           if (props.stats[vulnLevel] > 0) {
-            return (
-              <div className="pf-u-mb-sm" key={vulnLevel}>
-                <BundleIcon
-                  color={getSeverityColor(vulnLevel as VulnerabilitySeverity)}
-                  className="pf-u-mr-md"
-                />
-                <b>{props.stats[vulnLevel]}</b>
-                <PackageMessage vulnLevel={vulnLevel} />
-              </div>
-            );
+            return;
+            {
+              props.stats.Pending === 0 ? (
+                <div className="pf-u-mb-sm" key={vulnLevel}>
+                  <BundleIcon
+                    color={getSeverityColor(vulnLevel as VulnerabilitySeverity)}
+                    className="pf-u-mr-md"
+                  />
+                  <b>{props.stats[vulnLevel]}</b>
+                  <PackageMessage vulnLevel={vulnLevel} />
+                </div>
+              ) : (
+                <div></div>
+              );
+            }
           }
         })}
       </div>
@@ -58,27 +80,31 @@ function PackagesSummary(props: PackageStatsProps) {
 function PackagesDonutChart(props: PackageStatsProps) {
   return (
     <div style={{height: '20em', width: '20em'}}>
-      <ChartDonut
-        ariaDesc="packages chart"
-        ariaTitle="packages chart"
-        constrainToVisibleArea={true}
-        data={[
-          {x: VulnerabilitySeverity.Critical, y: props.stats.Critical},
-          {x: VulnerabilitySeverity.High, y: props.stats.High},
-          {x: VulnerabilitySeverity.Medium, y: props.stats.Medium},
-          {x: VulnerabilitySeverity.Unknown, y: props.stats.Unknown},
-          {x: VulnerabilitySeverity.None, y: props.stats.None},
-        ]}
-        colorScale={[
-          getSeverityColor(VulnerabilitySeverity.Critical),
-          getSeverityColor(VulnerabilitySeverity.High),
-          getSeverityColor(VulnerabilitySeverity.Medium),
-          getSeverityColor(VulnerabilitySeverity.Unknown),
-          getSeverityColor(VulnerabilitySeverity.None),
-        ]}
-        labels={({datum}) => `${datum.x}: ${datum.y}`}
-        title={`${props.total}`}
-      />
+      {props.stats.Pending > 0 ? (
+        <Skeleton shape="circle" width="100%" />
+      ) : (
+        <ChartDonut
+          ariaDesc="packages chart"
+          ariaTitle="packages chart"
+          constrainToVisibleArea={true}
+          data={[
+            {x: VulnerabilitySeverity.Critical, y: props.stats.Critical},
+            {x: VulnerabilitySeverity.High, y: props.stats.High},
+            {x: VulnerabilitySeverity.Medium, y: props.stats.Medium},
+            {x: VulnerabilitySeverity.Unknown, y: props.stats.Unknown},
+            {x: VulnerabilitySeverity.None, y: props.stats.None},
+          ]}
+          colorScale={[
+            getSeverityColor(VulnerabilitySeverity.Critical),
+            getSeverityColor(VulnerabilitySeverity.High),
+            getSeverityColor(VulnerabilitySeverity.Medium),
+            getSeverityColor(VulnerabilitySeverity.Unknown),
+            getSeverityColor(VulnerabilitySeverity.None),
+          ]}
+          labels={({datum}) => `${datum.x}: ${datum.y}`}
+          title={`${props.total}`}
+        />
+      )}
     </div>
   );
 }
@@ -92,42 +118,54 @@ export function PackagesChart(props: PackageChartProps) {
     Negligible: 0,
     Unknown: 0,
     None: 0,
+    Pending: 0,
   };
 
   let patchesAvailable = 0;
   let totalPackages = 0;
   let totalPackagesPerSeverity = 0;
-  props.features.map((feature) => {
-    totalPackages += 1;
-    const perPackageVulnStats = {
-      Critical: 0,
-      High: 0,
-      Medium: 0,
-      Low: 0,
-      Negligible: 0,
-      Unknown: 0,
-    };
 
-    feature.Vulnerabilities.map((vulnerability) => {
-      perPackageVulnStats[vulnerability.Severity] = 1;
-      if (vulnerability.FixedBy.length > 0) {
-        patchesAvailable += 1;
-      }
-    });
+  if (props.features) {
+    if (props.features.length > 0) {
+      props.features.map((feature) => {
+        totalPackages += 1;
+        const perPackageVulnStats = {
+          Critical: 0,
+          High: 0,
+          Medium: 0,
+          Low: 0,
+          Negligible: 0,
+          Unknown: 0,
+        };
 
-    // add perPackageStats to totals
-    Object.keys(perPackageVulnStats).map((severity) => {
-      stats[severity] += perPackageVulnStats[severity];
-      if (perPackageVulnStats[severity] > 0) {
-        totalPackagesPerSeverity += 1;
-      }
-    });
+        feature.Vulnerabilities.map((vulnerability) => {
+          perPackageVulnStats[vulnerability.Severity] = 1;
+          if (vulnerability.FixedBy.length > 0) {
+            patchesAvailable += 1;
+          }
+        });
 
-    if (feature.Vulnerabilities.length == 0) {
+        // add perPackageStats to totals
+        Object.keys(perPackageVulnStats).map((severity) => {
+          stats[severity] += perPackageVulnStats[severity];
+          if (perPackageVulnStats[severity] > 0) {
+            totalPackagesPerSeverity += 1;
+          }
+        });
+
+        if (feature.Vulnerabilities.length == 0) {
+          stats[VulnerabilitySeverity.None] += 1;
+          totalPackagesPerSeverity += 1;
+        }
+      });
+    } else {
+      // No packages found
       stats[VulnerabilitySeverity.None] += 1;
-      totalPackagesPerSeverity += 1;
     }
-  });
+  } else {
+    // Waiting on API call to finish
+    stats.Pending = 1;
+  }
 
   return (
     <PageSection variant={PageSectionVariants.light}>

--- a/src/routes/TagDetails/Packages/PackagesTable.tsx
+++ b/src/routes/TagDetails/Packages/PackagesTable.tsx
@@ -5,7 +5,6 @@ import {
   VulnerabilitySeverity,
   VulnerabilityOrder,
 } from 'src/resources/TagResource';
-import React from 'react';
 import {
   TableComposable,
   Thead,
@@ -14,7 +13,12 @@ import {
   Tbody,
   Td,
 } from '@patternfly/react-table';
-import {PageSection, PageSectionVariants, Title} from '@patternfly/react-core';
+import {
+  PageSection,
+  PageSectionVariants,
+  Spinner,
+  Title,
+} from '@patternfly/react-core';
 import {useRecoilState} from 'recoil';
 import {
   filteredPackagesListState,
@@ -145,32 +149,34 @@ export default function PackagesTable({features}: PackagesProps) {
   );
 
   useEffect(() => {
-    const packagesList: PackagesListItem[] = [];
-    features.map((feature: Feature) => {
-      packagesList.push({
-        PackageName: feature.Name,
-        CurrentVersion: feature.Version,
-        Vulnerabilities: feature.Vulnerabilities,
+    if (features) {
+      const packagesList: PackagesListItem[] = [];
+      features.map((feature: Feature) => {
+        packagesList.push({
+          PackageName: feature.Name,
+          CurrentVersion: feature.Version,
+          Vulnerabilities: feature.Vulnerabilities,
 
-        VulnerabilityCounts: getVulnerabilitiesCount(feature.Vulnerabilities),
-        HighestVulnerabilitySeverity: getHighestVulnerabilitySeverity(
-          feature.Vulnerabilities,
-        ),
+          VulnerabilityCounts: getVulnerabilitiesCount(feature.Vulnerabilities),
+          HighestVulnerabilitySeverity: getHighestVulnerabilitySeverity(
+            feature.Vulnerabilities,
+          ),
 
-        VulnerabilityCountsAfterFix: getVulnerabilitiesCount(
-          feature.Vulnerabilities,
-          true,
-        ),
-        HighestVulnerabilitySeverityAfterFix: getHighestVulnerabilitySeverity(
-          feature.Vulnerabilities,
-          true,
-        ),
-      } as PackagesListItem);
-    });
+          VulnerabilityCountsAfterFix: getVulnerabilitiesCount(
+            feature.Vulnerabilities,
+            true,
+          ),
+          HighestVulnerabilitySeverityAfterFix: getHighestVulnerabilitySeverity(
+            feature.Vulnerabilities,
+            true,
+          ),
+        } as PackagesListItem);
+      });
 
-    const sortedPackagesList = sortPackages(packagesList);
-    setPackagesList(sortedPackagesList);
-    setFilteredPackagesList(sortedPackagesList);
+      const sortedPackagesList = sortPackages(packagesList);
+      setPackagesList(sortedPackagesList);
+      setFilteredPackagesList(sortedPackagesList);
+    }
   }, [features]);
 
   return (
@@ -179,7 +185,7 @@ export default function PackagesTable({features}: PackagesProps) {
       <PackagesFilter />
       <TableComposable aria-label="packages table" variant={'compact'}>
         <TableHead />
-        {filteredPackagesList ? (
+        {filteredPackagesList.length !== 0 ? (
           filteredPackagesList.map((pkg: PackagesListItem) => {
             return (
               <Tbody key={pkg.PackageName + pkg.CurrentVersion}>
@@ -207,11 +213,11 @@ export default function PackagesTable({features}: PackagesProps) {
             );
           })
         ) : (
-          <tbody>
-            <tr>
-              <td> Loading</td>
-            </tr>
-          </tbody>
+          <Tbody>
+            <Tr>
+              <Td>{!features ? <Spinner size="lg" /> : <div></div>}</Td>
+            </Tr>
+          </Tbody>
         )}
       </TableComposable>
     </PageSection>

--- a/src/routes/TagDetails/SecurityReport/SecurityReport.tsx
+++ b/src/routes/TagDetails/SecurityReport/SecurityReport.tsx
@@ -1,35 +1,16 @@
-import {useEffect, useState} from 'react';
 import SecurityReportTable from './SecurityReportTable';
-import {
-  Data,
-  getSecurityDetails,
-  SecurityDetailsResponse,
-} from 'src/resources/TagResource';
 import {SecurityReportChart} from './SecurityReportChart';
-import {LoadingPage} from 'src/components/LoadingPage';
+import {useRecoilState} from 'recoil';
+import {SecurityDetailsState} from 'src/atoms/SecurityDetailsState';
 
 export default function SecurityReport(props: SecurityReportProps) {
-  const [data, setData] = useState<Data>(null);
+  const [data, setData] = useRecoilState(SecurityDetailsState);
 
-  // Grab security details based on digest
-  useEffect(() => {
-    if (props.digest !== '') {
-      (async () => {
-        try {
-          const securityDetails: SecurityDetailsResponse =
-            await getSecurityDetails(props.org, props.repo, props.digest);
-          setData(securityDetails.data);
-        } catch (error) {
-          console.error('Unable to get security details: ', error);
-        }
-      })();
-    }
-  }, [props.digest]);
-
-  let features = [];
+  // Set features to a default of null to distinuish between a completed API call and one that is in progress
+  let features = null;
 
   if (data) {
-    features = data.Layer.Features;
+    features = data.data.Layer.Features;
   }
 
   return (

--- a/src/routes/TagDetails/SecurityReport/SecurityReportTable.tsx
+++ b/src/routes/TagDetails/SecurityReport/SecurityReportTable.tsx
@@ -80,11 +80,16 @@ export default function SecurityReportTable({features}: SecurityDetailsProps) {
   const [expandedVulnKeys, setExpandedVulnKeys] = React.useState<string[]>([]);
 
   const generateUniqueKey = (vulnerability: VulnerabilityListItem) => {
-    let hashInput = vulnerability.Advisory + vulnerability.Description;
+    let hashInput =
+      vulnerability.PackageName +
+      vulnerability.Advisory +
+      vulnerability.Description +
+      vulnerability.Severity;
 
     if (vulnerability.Metadata) {
       hashInput += vulnerability.Metadata.RepoName;
     }
+
     return sha1(hashInput);
   };
 
@@ -97,24 +102,26 @@ export default function SecurityReportTable({features}: SecurityDetailsProps) {
   const isRepoExpanded = (key: string) => expandedVulnKeys.includes(key);
 
   useEffect(() => {
-    const vulnList: VulnerabilityListItem[] = [];
-    features.map((feature: Feature) => {
-      feature.Vulnerabilities.map((vulnerability: Vulnerability) => {
-        vulnList.push({
-          PackageName: feature.Name,
-          CurrentVersion: feature.Version,
-          Description: vulnerability.Description,
-          NamespaceName: vulnerability.NamespaceName,
-          Advisory: vulnerability.Name,
-          Severity: vulnerability.Severity,
-          FixedInVersion: vulnerability.FixedBy,
-          Metadata: vulnerability.Metadata,
-          Link: vulnerability.Link,
-        } as VulnerabilityListItem);
+    if (features) {
+      const vulnList: VulnerabilityListItem[] = [];
+      features.map((feature: Feature) => {
+        feature.Vulnerabilities.map((vulnerability: Vulnerability) => {
+          vulnList.push({
+            PackageName: feature.Name,
+            CurrentVersion: feature.Version,
+            Description: vulnerability.Description,
+            NamespaceName: vulnerability.NamespaceName,
+            Advisory: vulnerability.Name,
+            Severity: vulnerability.Severity,
+            FixedInVersion: vulnerability.FixedBy,
+            Metadata: vulnerability.Metadata,
+            Link: vulnerability.Link,
+          } as VulnerabilityListItem);
+        });
       });
-    });
-    setVulnList(vulnList);
-    setFilteredVulnList(vulnList);
+      setVulnList(vulnList);
+      setFilteredVulnList(vulnList);
+    }
   }, [features]);
 
   return (
@@ -206,9 +213,7 @@ export default function SecurityReportTable({features}: SecurityDetailsProps) {
         ) : (
           <Tbody>
             <Tr>
-              <Td>
-                <Spinner size="lg" />
-              </Td>
+              <Td>{!features ? <Spinner size="lg" /> : <div></div>}</Td>
             </Tr>
           </Tbody>
         )}

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -71,7 +71,6 @@ const config: Configuration = {
   devServer: {
     static: './dist',
     port: 9001,
-    historyApiFallback: true,
     // Allow bridge running in a container to connect to the plugin dev server.
     allowedHosts: 'all',
     headers: {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -13,7 +13,9 @@ module.exports = merge(common('development'), {
         host: HOST,
         port: PORT,
         compress: true,
-        historyApiFallback: true,
+        historyApiFallback: {
+            disableDotRule: true,
+          },
         open: true
     },
     module: {


### PR DESCRIPTION
* Fixes issue reloading pages locally that contained a tag with a `.` in the name
* Adds skeletons for Packages page [PROJQUAY-4243](https://issues.redhat.com/browse/PROJQUAY-4243)
* Handles security vulnerability timeouts on Tags page [PROJQUAY-4245](https://issues.redhat.com/browse/PROJQUAY-4245)
* Updates how unique table identifiers are calculated, makes them a little more unique
* Updates all Tag tabs to handle skeletons for three states: success, failure, pending