### PR TITLE
Adding error handling (PROJQUAY-4151)

### DIFF
--- a/src/atoms/SecurityDetailsState.ts
+++ b/src/atoms/SecurityDetailsState.ts
@@ -5,3 +5,8 @@ export const SecurityDetailsState = atom<SecurityDetailsResponse>({
   key: 'securityDetailsState',
   default: null,
 });
+
+export const SecurityDetailsErrorState = atom<string>({
+  key: 'securityDetailsErrorState',
+  default: null,
+});

--- a/src/atoms/UserState.ts
+++ b/src/atoms/UserState.ts
@@ -32,6 +32,10 @@ export const UserOrgs = selector<IOrganization[] | undefined>({
     // an error and if returns a 401 redirects to /signin
     if (user) {
       return [{name: user.username}, ...user.organizations];
+    } else {
+      console.error(
+        'Error getting organizations, recieved unexpected empty response from UserState',
+      );
     }
   },
 });

--- a/src/atoms/UserState.ts
+++ b/src/atoms/UserState.ts
@@ -1,18 +1,38 @@
 import {atom, selector} from 'recoil';
 import {IUserResource} from 'src/resources/UserResource';
 import {IOrganization} from 'src/resources/OrganisationResource';
+import {getUser} from 'src/resources/UserResource';
 
-// TODO: Error handling
-export const UserState = atom<IUserResource | undefined>({
+// Request ID is used to refresh userState via the API.
+// Updating UserRequestId get's the latest contents of
+// the user state.
+export const UserRequestId = atom({
+  key: 'userRequestId',
+  default: 0,
+});
+
+export const CurrentUsernameState = atom({
+  key: 'currentUsernameState',
+  default: '',
+});
+
+export const UserState = selector<IUserResource | undefined>({
   key: 'userState',
-  default: undefined,
+  get: async ({get}) => {
+    get(UserRequestId); // Add dep on UserRequestId to allow refreshes
+    return await getUser();
+  },
 });
 
 export const UserOrgs = selector<IOrganization[] | undefined>({
   key: 'userOrgs',
   get: async ({get}) => {
-    const user = get(UserState);
-    return user ? user.organizations : undefined;
+    const user: IUserResource = get(UserState);
+    // Check should never fail, if request was unsuccessful it throws
+    // an error and if returns a 401 redirects to /signin
+    if (user) {
+      return [{name: user.username}, ...user.organizations];
+    }
   },
 });
 

--- a/src/components/errors/ErrorBoundary.tsx
+++ b/src/components/errors/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+// Function getDerivedStateFromError required for Error Boundaries
+// are only available on class components
+class ErrorBoundary extends React.Component<
+  ErrorBoundryProps,
+  ErrorBoundryState
+> {
+  constructor(props: ErrorBoundryProps) {
+    super(props);
+    this.state = {
+      hasError: props.hasError,
+      fallback: props.fallback,
+    };
+  }
+
+  // Capture the error that occured when rendering child component
+  static getDerivedStateFromError(error) {
+    console.error(error);
+    return {hasError: true};
+  }
+
+  render() {
+    if (this.state.hasError || this.props.hasError) {
+      return <>{this.props.fallback}</>;
+    }
+    return <>{this.props.children}</>;
+  }
+}
+
+interface ErrorBoundryState {
+  hasError: boolean;
+  fallback: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+interface ErrorBoundryProps {
+  fallback: React.ReactNode;
+  hasError?: boolean;
+  children?: React.ReactNode;
+}
+
+export default ErrorBoundary;

--- a/src/components/errors/FormError.tsx
+++ b/src/components/errors/FormError.tsx
@@ -1,0 +1,22 @@
+import {Alert, AlertActionCloseButton} from '@patternfly/react-core';
+import {isErrorString} from 'src/resources/ErrorHandling';
+
+export default function FormError(props: FormErrorProps) {
+  if (!isErrorString(props.message)) {
+    return null;
+  }
+  return (
+    <Alert
+      id="form-error-alert"
+      isInline
+      actionClose={<AlertActionCloseButton onClose={() => props.setErr('')} />}
+      variant="danger"
+      title={props.message}
+    />
+  );
+}
+
+interface FormErrorProps {
+  message: string;
+  setErr: (tag: string) => void;
+}

--- a/src/components/errors/PageLoadError.tsx
+++ b/src/components/errors/PageLoadError.tsx
@@ -1,0 +1,30 @@
+import {
+  Brand,
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  PageSection,
+  Title,
+} from '@patternfly/react-core';
+import {ExclamationTriangleIcon} from '@patternfly/react-icons';
+
+// Looks the same as RequestError for now, will update later after
+// discussing what this should look like. Keeping as separate component
+// for now since it will change in the future.
+export default function PageLoadError() {
+  return (
+    <PageSection>
+      <EmptyState variant="full">
+        <EmptyStateIcon icon={ExclamationTriangleIcon} />
+        <Title headingLevel="h1" size="lg">
+          Unable to reach server
+        </Title>
+        <EmptyStateBody>Page could not be loaded</EmptyStateBody>
+        <Button title="Home" onClick={() => window.location.reload()}>
+          Retry
+        </Button>
+      </EmptyState>
+    </PageSection>
+  );
+}

--- a/src/components/errors/RequestError.tsx
+++ b/src/components/errors/RequestError.tsx
@@ -1,0 +1,30 @@
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  PageSection,
+  Title,
+} from '@patternfly/react-core';
+import {ExclamationTriangleIcon} from '@patternfly/react-icons';
+
+export default function RequestError(props: RequestErrorProps) {
+  return (
+    <PageSection>
+      <EmptyState variant="full">
+        <EmptyStateIcon icon={ExclamationTriangleIcon} />
+        <Title headingLevel="h1" size="lg">
+          Unable to complete request
+        </Title>
+        <EmptyStateBody>{props.message}</EmptyStateBody>
+        <Button title="Home" onClick={() => window.location.reload()}>
+          Retry
+        </Button>
+      </EmptyState>
+    </PageSection>
+  );
+}
+
+interface RequestErrorProps {
+  message: string;
+}

--- a/src/components/labels/Labels.tsx
+++ b/src/components/labels/Labels.tsx
@@ -8,6 +8,8 @@ import {Label} from '@patternfly/react-core';
 
 export default function Labels(props: LabelsProps) {
   const [labels, setLabels] = useState<ImageLabel[]>([]);
+  const [err, setErr] = useState<boolean>(false);
+
   useEffect(() => {
     (async () => {
       try {
@@ -19,9 +21,14 @@ export default function Labels(props: LabelsProps) {
         setLabels(labelsResp.labels);
       } catch (error: any) {
         console.error('Unable to get labels: ', error);
+        setErr(true);
       }
     })();
   }, []);
+
+  if (err) {
+    return <>Unable to get labels</>;
+  }
 
   return (
     <>

--- a/src/components/modals/BulkDeleteModalTemplate.tsx
+++ b/src/components/modals/BulkDeleteModalTemplate.tsx
@@ -19,6 +19,8 @@ import {
   Tr,
 } from '@patternfly/react-table';
 import {useEffect, useState} from 'react';
+import {addDisplayError} from 'src/resources/ErrorHandling';
+import FormError from '../errors/FormError';
 
 export const BulkDeleteModalTemplate = <T,>(
   props: BulkDeleteModalTemplateProps<T>,
@@ -37,6 +39,7 @@ export const BulkDeleteModalTemplate = <T,>(
     page: 1,
     perPage: 10,
   });
+  const [err, setErr] = useState<string>();
 
   const onSearch = (value: string) => {
     setSearchInput(value);
@@ -54,11 +57,16 @@ export const BulkDeleteModalTemplate = <T,>(
     }
   };
 
-  const bulkDelete = () => {
-    if (confirmDeletionInput === 'confirm') {
-      props.handleBulkDeletion(props.selectedItems);
-    }
+  const bulkDelete = async () => {
     // TODO:(harish) Ask UX for Alert msg in case text entered is invalid
+    if (confirmDeletionInput === 'confirm') {
+      try {
+        await props.handleBulkDeletion(props.selectedItems);
+      } catch (err) {
+        console.error(err);
+        setErr(addDisplayError('Unable to delete items', err));
+      }
+    }
   };
 
   useEffect(() => {
@@ -117,6 +125,7 @@ export const BulkDeleteModalTemplate = <T,>(
             </ToolbarItem>
           </ToolbarContent>
         </Toolbar>
+        <FormError message={err} setErr={setErr} />
         <TableComposable aria-label="Simple table" variant="compact">
           <Thead>
             <Tr>

--- a/src/components/toolbar/Kebab.tsx
+++ b/src/components/toolbar/Kebab.tsx
@@ -22,5 +22,5 @@ export function Kebab(props: KebabProps) {
 type KebabProps = {
   isKebabOpen: boolean;
   setKebabOpen: (open) => void;
-  kebabItems: React.FunctionComponent<DropdownItemProps>[];
+  kebabItems: React.ReactElement[];
 };

--- a/src/hooks/UseQuayConfig.ts
+++ b/src/hooks/UseQuayConfig.ts
@@ -10,9 +10,17 @@ export function useQuayConfig() {
 
   useEffect(() => {
     (async () => {
-      const config = await fetchQuayConfig();
-      setQuayConfig(config);
-      console.log(config);
+      // NOTE: Making the decision that loading the Quay configuration
+      // is not required. If the load fails the app will continue running.
+      // Components using this hook should check for null values. This
+      // behavior may change in the future.
+      try {
+        const config = await fetchQuayConfig();
+        setQuayConfig(config);
+        console.log(config);
+      } catch (err) {
+        console.error('Unable to load Quay config:', err);
+      }
     })();
   }, []);
   return quayConfig;

--- a/src/hooks/UseRefreshUser.ts
+++ b/src/hooks/UseRefreshUser.ts
@@ -1,0 +1,8 @@
+import {useSetRecoilState} from 'recoil';
+import {UserRequestId} from 'src/atoms/UserState';
+
+// Updates UserRequestId to refresh cache for UserState,
+export function useRefreshUser() {
+  const setUserRequestId = useSetRecoilState(UserRequestId);
+  return () => setUserRequestId((requestId) => requestId + 1);
+}

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -12,21 +12,16 @@ axios.defaults.withCredentials = true;
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 export async function getCsrfToken() {
-  try {
-    if (process.env.MOCK_API === 'true') {
-      return 'test-csrf-token';
-    }
-    const response = await axios.get('/csrf_token');
-    GlobalAuthState.csrfToken = response.data.csrf_token;
-    return response.data;
-  } catch (error) {
-    throw new Error(`API error login user ${error.message}`);
+  if (process.env.MOCK_API === 'true') {
+    return 'test-csrf-token';
   }
+  const response = await axios.get('/csrf_token');
+  GlobalAuthState.csrfToken = response.data.csrf_token;
+  return response.data;
 }
 
 const axiosIns = axios.create();
 axiosIns.interceptors.request.use(async (config) => {
-  // TODO: Handle error if we can't get a CSRF token
   if (!GlobalAuthState.csrfToken) {
     const r = await getCsrfToken();
     GlobalAuthState.csrfToken = r.csrf_token;
@@ -39,15 +34,16 @@ axiosIns.interceptors.request.use(async (config) => {
   return config;
 });
 
+// Catches errors thrown in axiosIns.interceptors.request.use
 axiosIns.interceptors.response.use(
   (response) => {
     return response;
   },
   (error) => {
-    // console.error(error)
-    if (error.response.status === 401) {
+    if (error.response?.status === 401) {
       window.location.href = '/signin';
     }
+    throw error; // Rethrow error to be handled in components
   },
 );
 

--- a/src/resources/AuthResource.ts
+++ b/src/resources/AuthResource.ts
@@ -1,4 +1,5 @@
 import axios from 'src/libs/axios';
+import {assertHttpCode} from './ErrorHandling';
 
 const signinApiUrl = '/api/v1/signin';
 const signoutApiUrl = '/api/v1/signout';
@@ -15,39 +16,28 @@ export const GlobalAuthState: AuthResource = {
 };
 
 export async function loginUser(username: string, password: string) {
-  try {
-    const response = await axios.post(signinApiUrl, {
-      username: username,
-      password: password,
-    });
-    if (response.data == 'success') {
-      GlobalAuthState.isLoggedIn = true;
-      // reset csrf token
-      GlobalAuthState.csrfToken = undefined;
-    }
-    return response.data;
-  } catch (error: any) {
-    throw new Error(`API error login user ${error.message}`);
+  const response = await axios.post(signinApiUrl, {
+    username: username,
+    password: password,
+  });
+  if (response.data == 'success') {
+    GlobalAuthState.isLoggedIn = true;
+    GlobalAuthState.csrfToken = undefined;
   }
+  return response.data;
 }
 
 export async function logoutUser() {
-  try {
-    const response = await axios.post(signoutApiUrl);
-    GlobalAuthState.isLoggedIn = false;
-    GlobalAuthState.csrfToken = undefined;
-    return response.data;
-  } catch (error: any) {
-    throw new Error(`API error login user ${error.message}`);
-  }
+  const response = await axios.post(signoutApiUrl);
+  assertHttpCode(response.status, 200);
+  GlobalAuthState.isLoggedIn = false;
+  GlobalAuthState.csrfToken = undefined;
+  return response.data;
 }
 
 export async function getCsrfToken() {
-  try {
-    const response = await axios.get(csrfTokenUrl);
-    GlobalAuthState.csrfToken = response.data.csrf_token;
-    return response.data;
-  } catch (error: any) {
-    throw new Error(`API error login user ${error.message}`);
-  }
+  const response = await axios.get(csrfTokenUrl);
+  assertHttpCode(response.status, 200);
+  GlobalAuthState.csrfToken = response.data.csrf_token;
+  return response.data;
 }

--- a/src/resources/ErrorHandling.ts
+++ b/src/resources/ErrorHandling.ts
@@ -1,0 +1,16 @@
+import {AxiosError} from 'axios';
+
+export function addDisplayError(message: string, error: Error | AxiosError) {
+  // Add user friendly description of error
+  return message + ', ' + error.message + '.';
+}
+
+export function assertHttpCode(got: number, expected: number) {
+  if (expected !== got) {
+    throw new Error(`Unexpected HTTP status code: ${got}`);
+  }
+}
+
+export function isErrorString(err: string) {
+  return typeof err === 'string' && err.length > 0;
+}

--- a/src/resources/QuayConfig.ts
+++ b/src/resources/QuayConfig.ts
@@ -2,13 +2,11 @@
 
 import {AxiosResponse} from 'axios';
 import axios from '../libs/axios';
+import {assertHttpCode} from './ErrorHandling';
 
 export async function fetchQuayConfig() {
-  const configUrl = '/config';
-  try {
-    const response: AxiosResponse = await axios.get(configUrl);
-    return response.data;
-  } catch (e) {
-    console.error(e);
-  }
+  // TODO: Add response type to AxiosResponse
+  const response: AxiosResponse = await axios.get('/config');
+  assertHttpCode(response.status, 200);
+  return response.data;
 }

--- a/src/resources/RepositoryResource.ts
+++ b/src/resources/RepositoryResource.ts
@@ -1,5 +1,6 @@
 import {AxiosResponse} from 'axios';
 import axios from 'src/libs/axios';
+import {assertHttpCode} from './ErrorHandling';
 
 export interface IRepository {
   namespace: string;
@@ -20,18 +21,26 @@ export interface RepositoryCreationResponse {
 }
 
 export async function fetchAllRepos(namespaces: string[]) {
-  try {
-    const repoList = await Promise.all(
-      namespaces.map((ns) => {
-        return axios.get(
-          `/api/v1/repository?last_modified=true&namespace=${ns}`,
-        );
-      }),
-    );
-    return repoList;
-  } catch (error) {
-    console.error(error);
-  }
+  const namespacedRepos = await Promise.all(
+    namespaces.map((ns) => {
+      return getRepositoriesForNamespace(ns);
+    }),
+  );
+  // Flatten responses to a single list of all repositories
+  return namespacedRepos.reduce(
+    (allRepos, namespacedRepos) =>
+      allRepos.concat(namespacedRepos.repositories),
+    [],
+  );
+}
+
+export async function getRepositoriesForNamespace(ns: string) {
+  // TODO: Add return type to AxiosResponse
+  const response: AxiosResponse = await axios.get(
+    `/api/v1/repository?last_modified=true&namespace=${ns}`,
+  );
+  assertHttpCode(response.status, 200);
+  return response.data;
 }
 
 export async function createNewRepository(
@@ -42,19 +51,18 @@ export async function createNewRepository(
   repo_kind: string,
 ) {
   const newRepositoryApiUrl = `/api/v1/repository`;
-  try {
-    const response: AxiosResponse<RepositoryCreationResponse> =
-      await axios.post(newRepositoryApiUrl, {
-        namespace,
-        repository,
-        visibility,
-        description,
-        repo_kind,
-      });
-    return response;
-  } catch (e) {
-    console.error(e);
-  }
+  const response: AxiosResponse<RepositoryCreationResponse> = await axios.post(
+    newRepositoryApiUrl,
+    {
+      namespace,
+      repository,
+      visibility,
+      description,
+      repo_kind,
+    },
+  );
+  assertHttpCode(response.status, 201);
+  return response.data;
 }
 
 export async function setRepositoryVisibility(
@@ -62,34 +70,28 @@ export async function setRepositoryVisibility(
   repositoryName: string,
   visibility: string,
 ) {
-  const repositoryVisibilityUrl =
-    `/api/v1/repository/` +
-    namespace +
-    `/` +
-    repositoryName +
-    `/changevisibility`;
-  try {
-    const response = await axios.post(repositoryVisibilityUrl, {
-      visibility,
-    });
-    return response;
-  } catch (e) {
-    // TODO: Find a better way to propagate errors
-    console.error(e);
-  }
+  // TODO: Add return type to AxiosResponse
+  const api = `/api/v1/repository/${namespace}/${repositoryName}/changevisibility`;
+  const response: AxiosResponse = await axios.post(api, {
+    visibility,
+  });
+  assertHttpCode(response.status, 200);
+  return response.data;
 }
 
 export async function bulkDeleteRepositories(repos: IRepository[]) {
-  try {
-    const response = await Promise.all(
-      repos.map((repo) => {
-        return axios.delete(
-          `/api/v1/repository/${repo.namespace + '/' + repo.name}`,
-        );
-      }),
-    );
-    return response;
-  } catch (error) {
-    console.error(error);
-  }
+  await Promise.all(
+    repos.map((repo) => {
+      return deleteRepository(repo.namespace, repo.name);
+    }),
+  );
+}
+
+// Not returning response from deleting repository for now as
+// it's not required but may want to add it in the future.
+export async function deleteRepository(ns: string, name: string) {
+  const response: AxiosResponse = await axios.delete(
+    `/api/v1/repository/${ns}/${name}`,
+  );
+  assertHttpCode(response.status, 204);
 }

--- a/src/resources/TagResource.ts
+++ b/src/resources/TagResource.ts
@@ -1,5 +1,6 @@
 import {AxiosResponse} from 'axios';
 import axios from 'src/libs/axios';
+import {assertHttpCode} from './ErrorHandling';
 
 export interface TagsResponse {
   page: number;
@@ -129,37 +130,38 @@ export async function getTags(
   limit = 100,
   specificTag = null,
 ) {
-  try {
-    let path = `/api/v1/repository/${org}/${repo}/tag/?limit=${limit}&page=${page}&onlyActiveTags=true`;
-    if (specificTag) {
-      path = path.concat(`&specificTag=${specificTag}`);
-    }
-    const response: AxiosResponse<TagsResponse> = await axios.get(path);
-    return response.data;
-  } catch (error: any) {
-    throw new Error(`API error getting tags ${error.message}`);
+  let path = `/api/v1/repository/${org}/${repo}/tag/?limit=${limit}&page=${page}&onlyActiveTags=true`;
+  if (specificTag) {
+    path = path.concat(`&specificTag=${specificTag}`);
   }
+  const response: AxiosResponse<TagsResponse> = await axios.get(path);
+  assertHttpCode(response.status, 200);
+  return response.data;
 }
 
 export async function getLabels(org: string, repo: string, digest: string) {
-  try {
-    const response: AxiosResponse<LabelsResponse> = await axios.get(
-      `/api/v1/repository/${org}/${repo}/manifest/${digest}/labels`,
-    );
-    return response.data;
-  } catch (error: any) {
-    throw new Error(`API error getting labels ${error.message}`);
-  }
+  const response: AxiosResponse<LabelsResponse> = await axios.get(
+    `/api/v1/repository/${org}/${repo}/manifest/${digest}/labels`,
+  );
+  assertHttpCode(response.status, 200);
+  return response.data;
+}
+
+interface TagLocation {
+  org: string;
+  repo: string;
+  tag: string;
+}
+
+export async function bulkDeleteTags(tags: TagLocation[]) {
+  await Promise.all(tags.map((tag) => deleteTag(tag.org, tag.repo, tag.tag)));
 }
 
 export async function deleteTag(org: string, repo: string, tag: string) {
-  try {
-    const response: AxiosResponse = await axios.delete(
-      `/api/v1/repository/${org}/${repo}/tag/${tag}`,
-    );
-  } catch (error: any) {
-    throw new Error(`API error deleting tags ${error.message}`);
-  }
+  const response: AxiosResponse = await axios.delete(
+    `/api/v1/repository/${org}/${repo}/tag/${tag}`,
+  );
+  assertHttpCode(response.status, 204);
 }
 
 export async function getManifestByDigest(
@@ -167,14 +169,11 @@ export async function getManifestByDigest(
   repo: string,
   digest: string,
 ) {
-  try {
-    const response: AxiosResponse<ManifestByDigestResponse> = await axios.get(
-      `/api/v1/repository/${org}/${repo}/manifest/${digest}`,
-    );
-    return response.data;
-  } catch (error: any) {
-    throw new Error(`API error getting manifest by digest ${error.message}`);
-  }
+  const response: AxiosResponse<ManifestByDigestResponse> = await axios.get(
+    `/api/v1/repository/${org}/${repo}/manifest/${digest}`,
+  );
+  assertHttpCode(response.status, 200);
+  return response.data;
 }
 
 export async function getSecurityDetails(
@@ -182,12 +181,9 @@ export async function getSecurityDetails(
   repo: string,
   digest: string,
 ) {
-  try {
-    const response: AxiosResponse<SecurityDetailsResponse> = await axios.get(
-      `/api/v1/repository/${org}/${repo}/manifest/${digest}/security?vulnerabilities=true`,
-    );
-    return response.data;
-  } catch (error: any) {
-    throw new Error(`API error getting security details ${error.message}`);
-  }
+  const response: AxiosResponse<SecurityDetailsResponse> = await axios.get(
+    `/api/v1/repository/${org}/${repo}/manifest/${digest}/security?vulnerabilities=true`,
+  );
+  assertHttpCode(response.status, 200);
+  return response.data;
 }

--- a/src/resources/UserResource.ts
+++ b/src/resources/UserResource.ts
@@ -1,4 +1,6 @@
+import {AxiosResponse} from 'axios';
 import axios from 'src/libs/axios';
+import {assertHttpCode} from './ErrorHandling';
 import {IAvatar, IOrganization} from './OrganisationResource';
 
 export interface IUserResource {
@@ -33,10 +35,9 @@ export interface IUserResource {
 }
 
 export async function getUser() {
-  try {
-    const response = await axios.get('/api/v1/user/');
-    return response.data;
-  } catch (error) {
-    throw new Error(`API error getting user ${error.message}`);
-  }
+  const response: AxiosResponse<IUserResource> = await axios.get(
+    '/api/v1/user/',
+  );
+  assertHttpCode(response.status, 200);
+  return response.data;
 }

--- a/src/routes/OrganizationsList/CreateOrganizationModal.tsx
+++ b/src/routes/OrganizationsList/CreateOrganizationModal.tsx
@@ -12,19 +12,19 @@ import {
 } from '@patternfly/react-core';
 import './css/Organizations.scss';
 import {createOrg} from 'src/resources/OrganisationResource';
-import {useRecoilState} from 'recoil';
-import {UserState} from 'src/atoms/UserState';
-import {getUser} from 'src/resources/UserResource';
 import {isValidEmail} from 'src/libs/utils';
 import {useState} from 'react';
+import FormError from 'src/components/errors/FormError';
+import {useRefreshUser} from 'src/hooks/UseRefreshUser';
 
 export const CreateOrganizationModal = (
   props: CreateOrganizationModalProps,
 ): JSX.Element => {
   const [organizationName, setOrganizationName] = useState('');
   const [organizationEmail, setOrganizationEmail] = useState('');
-  const [, setUserState] = useRecoilState(UserState);
   const [invalidEmailFlag, setInvalidEmailFlag] = useState(false);
+  const [err, setErr] = useState<string>();
+  const refreshUser = useRefreshUser();
 
   const handleNameInputChange = (value: any) => {
     setOrganizationName(value);
@@ -35,11 +35,15 @@ export const CreateOrganizationModal = (
   };
 
   const createOrganizationHandler = async () => {
-    const response = await createOrg(organizationName, organizationEmail);
-    props.handleModalToggle();
-    if (response === 'Created') {
-      const user = await getUser();
-      setUserState(user);
+    try {
+      const response = await createOrg(organizationName, organizationEmail);
+      props.handleModalToggle();
+      if (response === 'Created') {
+        refreshUser();
+      }
+    } catch (err) {
+      console.error(err);
+      setErr('Unable to create organization');
     }
   };
 
@@ -74,6 +78,7 @@ export const CreateOrganizationModal = (
         </Button>,
       ]}
     >
+      <FormError message={err} setErr={setErr} />
       <Form id="modal-with-form-form" isWidthLimited>
         <FormGroup
           isInline

--- a/src/routes/OrganizationsList/OrganizationToolBar.tsx
+++ b/src/routes/OrganizationsList/OrganizationToolBar.tsx
@@ -8,7 +8,6 @@ import {ToolbarPagination} from 'src/components/toolbar/Pagination';
 import {filterOrgState} from 'src/atoms/UserState';
 import {useRecoilState} from 'recoil';
 import * as React from 'react';
-import {DropdownItemProps} from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
 
 export function OrganizationToolBar(props: OrganizationToolBarProps) {
   const [filterOrg, setOrgFilter] = useRecoilState(filterOrgState);
@@ -66,7 +65,7 @@ type OrganizationToolBarProps = {
   setOrganizationModalOpen: (open) => void;
   isKebabOpen: boolean;
   setKebabOpen: (open) => void;
-  kebabItems: React.FunctionComponent<DropdownItemProps>[];
+  kebabItems: React.ReactElement[];
   selectedOrganization: any[];
   deleteKebabIsOpen: boolean;
   deleteModal: object;

--- a/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -215,7 +215,6 @@ function RepoListContent(props: RepoListContentProps) {
         }));
         setRepositoryList(formattedRepos);
       } catch (err) {
-        console.log('setting err');
         console.error(err);
         props.setErr(addDisplayError('Unable to get repositores', err));
       }

--- a/src/routes/RepositoriesList/RepositoryToolBar.tsx
+++ b/src/routes/RepositoriesList/RepositoryToolBar.tsx
@@ -8,8 +8,7 @@ import {Kebab} from 'src/components/toolbar/Kebab';
 import {ConfirmationModal} from 'src/components/modals/ConfirmationModal';
 import {ToolbarPagination} from 'src/components/toolbar/Pagination';
 import {filterRepoState} from 'src/atoms/RepositoryState';
-import * as React from 'react';
-import {DropdownItemProps} from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
+import {ReactElement} from 'react';
 
 export function RepositoryToolBar(props: RepositoryToolBarProps) {
   const [filterRepo, setRepoFilter] = useRecoilState(filterRepoState);
@@ -117,7 +116,7 @@ type RepositoryToolBarProps = {
   setCreateRepoModalOpen: (open) => void;
   isKebabOpen: boolean;
   setKebabOpen: (open) => void;
-  kebabItems: React.FunctionComponent<DropdownItemProps>[];
+  kebabItems: ReactElement[];
   selectedRepoNames: any[];
   deleteModal: object;
   deleteKebabIsOpen: boolean;

--- a/src/routes/RepositoryDetails/Tags/DeleteModal.tsx
+++ b/src/routes/RepositoryDetails/Tags/DeleteModal.tsx
@@ -1,16 +1,26 @@
 import {Modal, ModalVariant, Button, Label} from '@patternfly/react-core';
-import {deleteTag} from 'src/resources/TagResource';
+import {useState} from 'react';
+import FormError from 'src/components/errors/FormError';
+import {bulkDeleteTags} from 'src/resources/TagResource';
 
 export function DeleteModal(props: ModalProps) {
+  const [err, setErr] = useState<string>();
   const deleteTags = async () => {
-    await Promise.all(
-      props.selectedTags.map(async (tag) =>
-        deleteTag(props.org, props.repo, tag),
-      ),
-    );
-    props.loadTags();
-    props.setIsOpen(!props.isOpen);
-    props.setSelectedTags([]);
+    try {
+      const tags = props.selectedTags.map((tag) => ({
+        org: props.org,
+        repo: props.repo,
+        tag: tag,
+      }));
+      await bulkDeleteTags(tags);
+      props.loadTags();
+      props.setIsOpen(!props.isOpen);
+      props.setSelectedTags([]);
+    } catch (err: any) {
+      console.error(err);
+      // TODO: Add to message the tags that weren't able to be deleted
+      setErr('Unable to delete tags');
+    }
   };
   return (
     <Modal
@@ -44,6 +54,7 @@ export function DeleteModal(props: ModalProps) {
         </Button>,
       ]}
     >
+      <FormError message={err} setErr={setErr} />
       {props.selectedTags.map((tag) => (
         <span key={tag}>
           <Label>{tag}</Label>{' '}

--- a/src/routes/StandaloneMain.tsx
+++ b/src/routes/StandaloneMain.tsx
@@ -1,19 +1,22 @@
-import {useEffect} from 'react';
 import {Page} from '@patternfly/react-core';
 
 import {Navigate, Outlet, Route, Routes} from 'react-router-dom';
 
 import {QuayHeader} from 'src/components/header/QuayHeader';
 import {QuaySidebar} from 'src/components/sidebar/QuaySidebar';
-import {getUser} from 'src/resources/UserResource';
-import {useRecoilState} from 'recoil';
-import {UserState} from 'src/atoms/UserState';
 import {NavigationPath} from './NavigationPath';
 import OrganizationsList from './OrganizationsList/OrganizationsList';
 import Organization from './OrganizationsList/Organization/Organization';
 import RepositoryDetails from 'src/routes/RepositoryDetails/RepositoryDetails';
 import RepositoriesList from './RepositoriesList/RepositoriesList';
 import TagDetails from 'src/routes/TagDetails/TagDetails';
+import {useEffect, useState} from 'react';
+import {getUser} from 'src/resources/UserResource';
+import {useSetRecoilState} from 'recoil';
+import {CurrentUsernameState} from 'src/atoms/UserState';
+import {isErrorString} from 'src/resources/ErrorHandling';
+import ErrorBoundary from 'src/components/errors/ErrorBoundary';
+import PageLoadError from 'src/components/errors/PageLoadError';
 
 const NavigationRoutes = [
   {
@@ -39,27 +42,36 @@ const NavigationRoutes = [
 ];
 
 export function StandaloneMain() {
-  const [, setUserState] = useRecoilState(UserState);
-
+  const setCurrentUsername = useSetRecoilState(CurrentUsernameState);
+  const [err, setErr] = useState<string>();
   useEffect(() => {
-    getUser().then((user) => setUserState(user));
+    (async () => {
+      try {
+        const user = await getUser();
+        setCurrentUsername(user.username);
+      } catch (err) {
+        console.error(err);
+        setErr('Unable to load page');
+      }
+    })();
   }, []);
-
   return (
-    <Page
-      header={<QuayHeader />}
-      sidebar={<QuaySidebar />}
-      style={{height: '100vh'}}
-      isManagedSidebar
-      defaultManagedSidebarIsOpen={true}
-    >
-      <Routes>
-        <Route index element={<Navigate to="/organizations" replace />} />
-        {NavigationRoutes.map(({path, Component}, key) => (
-          <Route path={path} key={key} element={Component} />
-        ))}
-      </Routes>
-      <Outlet />
-    </Page>
+    <ErrorBoundary hasError={isErrorString(err)} fallback={<PageLoadError />}>
+      <Page
+        header={<QuayHeader />}
+        sidebar={<QuaySidebar />}
+        style={{height: '100vh'}}
+        isManagedSidebar
+        defaultManagedSidebarIsOpen={true}
+      >
+        <Routes>
+          <Route index element={<Navigate to="/organizations" replace />} />
+          {NavigationRoutes.map(({path, Component}, key) => (
+            <Route path={path} key={key} element={Component} />
+          ))}
+        </Routes>
+        <Outlet />
+      </Page>
+    </ErrorBoundary>
   );
 }

--- a/src/routes/TagDetails/Packages/Packages.tsx
+++ b/src/routes/TagDetails/Packages/Packages.tsx
@@ -1,10 +1,20 @@
 import {PackagesChart} from './PackagesChart';
 import PackagesTable from './PackagesTable';
-import {useRecoilState} from 'recoil';
-import {SecurityDetailsState} from 'src/atoms/SecurityDetailsState';
+import {useRecoilState, useRecoilValue} from 'recoil';
+import {
+  SecurityDetailsErrorState,
+  SecurityDetailsState,
+} from 'src/atoms/SecurityDetailsState';
+import {isErrorString} from 'src/resources/ErrorHandling';
+import RequestError from 'src/components/errors/RequestError';
 
 export function Packages(props: PackagesProps) {
-  const [data, setData] = useRecoilState(SecurityDetailsState);
+  const data = useRecoilValue(SecurityDetailsState);
+  const error = useRecoilValue(SecurityDetailsErrorState);
+
+  if (isErrorString(error)) {
+    return <RequestError message={error} />;
+  }
 
   // Set features to a default of null to distinguish between a completed API call and one that is in progress
   let features = null;

--- a/src/routes/TagDetails/SecurityReport/SecurityReport.tsx
+++ b/src/routes/TagDetails/SecurityReport/SecurityReport.tsx
@@ -1,10 +1,20 @@
 import SecurityReportTable from './SecurityReportTable';
 import {SecurityReportChart} from './SecurityReportChart';
-import {useRecoilState} from 'recoil';
-import {SecurityDetailsState} from 'src/atoms/SecurityDetailsState';
+import {useRecoilState, useRecoilValue} from 'recoil';
+import {
+  SecurityDetailsErrorState,
+  SecurityDetailsState,
+} from 'src/atoms/SecurityDetailsState';
+import {isErrorString} from 'src/resources/ErrorHandling';
+import RequestError from 'src/components/errors/RequestError';
 
 export default function SecurityReport(props: SecurityReportProps) {
-  const [data, setData] = useRecoilState(SecurityDetailsState);
+  const data = useRecoilValue(SecurityDetailsState);
+  const error = useRecoilValue(SecurityDetailsErrorState);
+
+  if (isErrorString(error)) {
+    return <RequestError message={error} />;
+  }
 
   // Set features to a default of null to distinuish between a completed API call and one that is in progress
   let features = null;

--- a/src/routes/TagDetails/TagDetails.tsx
+++ b/src/routes/TagDetails/TagDetails.tsx
@@ -6,7 +6,6 @@ import {
   PageSectionVariants,
   Title,
   PageBreadcrumb,
-  Spinner,
 } from '@patternfly/react-core';
 import {useSearchParams, useLocation} from 'react-router-dom';
 import {useState, useEffect} from 'react';
@@ -20,10 +19,12 @@ import {
   ManifestByDigestResponse,
   Manifest,
 } from 'src/resources/TagResource';
+import {addDisplayError} from 'src/resources/ErrorHandling';
 
 export default function TagDetails() {
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const [architecture, setArchitecture] = useState<string>();
+  const [err, setErr] = useState<string>();
   const [tagDetails, setTagDetails] = useState<Tag>({
     name: '',
     is_manifest_list: false,
@@ -78,11 +79,11 @@ export default function TagDetails() {
           );
         }
       } catch (error: any) {
-        // TODO: provide sufficient error handling, will be resolved in a future PR
         console.error(error);
+        setErr(addDisplayError('Unable to get details for tag', error));
       }
     })();
-  }, [getTags, tagDetails.size]);
+  }, []);
 
   // Pull size and digest from manifest otherwise default to pull from tagDetails
   let size: number = tagDetails.size;
@@ -130,6 +131,7 @@ export default function TagDetails() {
           tag={tagDetails}
           size={size}
           digest={digest}
+          err={err}
         />
       </PageSection>
     </Page>

--- a/src/routes/TagDetails/TagDetailsTabs.tsx
+++ b/src/routes/TagDetails/TagDetailsTabs.tsx
@@ -6,6 +6,9 @@ import SecurityReport from './SecurityReport/SecurityReport';
 import {Tag} from 'src/resources/TagResource';
 import {TabIndex} from './Types';
 import {Packages} from './Packages/Packages';
+import ErrorBoundary from 'src/components/errors/ErrorBoundary';
+import {isErrorString} from 'src/resources/ErrorHandling';
+import RequestError from 'src/components/errors/RequestError';
 
 // Return the tab as an enum or null if it does not exist
 function getTabIndex(tab: string) {
@@ -35,29 +38,44 @@ export default function TagTabs(props: TagTabsProps) {
         eventKey={TabIndex.Details}
         title={<TabTitleText>Details</TabTitleText>}
       >
-        <Details
-          org={props.org}
-          repo={props.repo}
-          tag={props.tag}
-          size={props.size}
-          digest={props.digest}
-        />
+        <ErrorBoundary
+          hasError={isErrorString(props.err)}
+          fallback={<RequestError message={props.err} />}
+        >
+          <Details
+            org={props.org}
+            repo={props.repo}
+            tag={props.tag}
+            size={props.size}
+            digest={props.digest}
+          />
+        </ErrorBoundary>
       </Tab>
       <Tab
         eventKey={TabIndex.SecurityReport}
         title={<TabTitleText>Security Report</TabTitleText>}
       >
-        <SecurityReport
-          org={props.org}
-          repo={props.repo}
-          digest={props.digest}
-        />
+        <ErrorBoundary
+          hasError={isErrorString(props.err)}
+          fallback={<RequestError message={props.err} />}
+        >
+          <SecurityReport
+            org={props.org}
+            repo={props.repo}
+            digest={props.digest}
+          />
+        </ErrorBoundary>
       </Tab>
       <Tab
         eventKey={TabIndex.Packages}
         title={<TabTitleText>Packages</TabTitleText>}
       >
-        <Packages org={props.org} repo={props.repo} digest={props.digest} />
+        <ErrorBoundary
+          hasError={isErrorString(props.err)}
+          fallback={<RequestError message={props.err} />}
+        >
+          <Packages org={props.org} repo={props.repo} digest={props.digest} />
+        </ErrorBoundary>
       </Tab>
     </Tabs>
   );
@@ -69,4 +87,5 @@ type TagTabsProps = {
   repo: string;
   size: number;
   digest: string;
+  err: string;
 };


### PR DESCRIPTION
**Read before reviewing**

Detailed error messages are not included in this PR and will be implemented in a future PR. This PR creates the structure required for sufficient error handling.

The size of this PR is due to implementing the same change across all components making API calls.

**Summary of changes**
- Catching and handling or error's in each component
- Addition of an [ErrorBoundary](https://reactjs.org/docs/error-boundaries.html) and various display errors.
- Refactoring of API calls
    - Removed catching and re-throwing of errors - errors will be caught and handled in the components that use them
    - Assertion of the expected HTTP status code
    - Calls to `getUser`("/api/v1/user/") are consolidated in the `UserState` selector
    - Restructuring of calls

**How to test**
Replace various responses in `test/fake-db/data` with 500 error codes and run `MOCK_API=true npm start`. Can also run the UI with no Quay backend.



