### PR TITLE
errors: User facing formatting (PROJQUAY-4378)

### DIFF
--- a/src/components/LoadingPage.tsx
+++ b/src/components/LoadingPage.tsx
@@ -6,9 +6,7 @@ import {
   EmptyStateSecondaryActions,
   Title,
   Spinner,
-  PageSection,
   Bullseye,
-  Page,
 } from '@patternfly/react-core';
 
 export function LoadingPage(props: {
@@ -18,24 +16,20 @@ export function LoadingPage(props: {
   secondaryActions?: React.ReactNode;
 }) {
   return (
-    <Page>
-      <PageSection variant="light" isFilled>
-        <Bullseye>
-          <EmptyState>
-            <EmptyStateIcon variant="container" component={Spinner} />
-            <div>
-              <Title size="lg" headingLevel="h4">
-                {props.title ?? 'Loading'}
-              </Title>
-              <EmptyStateBody>{props.message}</EmptyStateBody>
-            </div>
-            {props.primaryAction}
-            <EmptyStateSecondaryActions>
-              {props.secondaryActions}
-            </EmptyStateSecondaryActions>
-          </EmptyState>
-        </Bullseye>
-      </PageSection>
-    </Page>
+    <Bullseye>
+      <EmptyState>
+        <EmptyStateIcon variant="container" component={Spinner} />
+        <div>
+          <Title size="lg" headingLevel="h4">
+            {props.title ?? 'Loading'}
+          </Title>
+          <EmptyStateBody>{props.message}</EmptyStateBody>
+        </div>
+        {props.primaryAction}
+        <EmptyStateSecondaryActions>
+          {props.secondaryActions}
+        </EmptyStateSecondaryActions>
+      </EmptyState>
+    </Bullseye>
   );
 }

--- a/src/components/errors/ErrorModal.tsx
+++ b/src/components/errors/ErrorModal.tsx
@@ -1,0 +1,33 @@
+import {Modal, ModalVariant} from '@patternfly/react-core';
+import {ExclamationCircleIcon} from '@patternfly/react-icons';
+
+export default function ErrorModal(props: ErrorModalProps) {
+  let err = props.error;
+  if (Array.isArray(err)) {
+    err = err.map((e) => (
+      <div key={e}>
+        <ExclamationCircleIcon color="red" /> {e}
+        <br />
+      </div>
+    ));
+  }
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      position="top"
+      aria-label="error modal"
+      title={props.title}
+      isOpen={props.error != null}
+      onClose={() => props.setError(null)}
+    >
+      {err}
+    </Modal>
+  );
+}
+
+interface ErrorModalProps {
+  error: string | string[] | React.ReactNode;
+  setError: (err: any) => void;
+  title?: string;
+}

--- a/src/components/errors/SiteUnavailableError.tsx
+++ b/src/components/errors/SiteUnavailableError.tsx
@@ -1,0 +1,33 @@
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Page,
+  PageSection,
+  Title,
+} from '@patternfly/react-core';
+import {ExclamationCircleIcon} from '@patternfly/react-icons';
+
+export default function SiteUnavailableError() {
+  return (
+    <Page>
+      <PageSection>
+        <EmptyState variant="full">
+          <EmptyStateIcon icon={ExclamationCircleIcon} />
+          <Title headingLevel="h1" size="lg">
+            This site is temporarily unavailable
+          </Title>
+          <EmptyStateBody>
+            Try refreshing the page. If the problem persists, contact your
+            organization administrator or visit our{' '}
+            <a href="https://status.quay.io/">status page</a> for known outages.
+          </EmptyStateBody>
+          <Button title="Home" onClick={() => window.location.reload()}>
+            Reload
+          </Button>
+        </EmptyState>
+      </PageSection>
+    </Page>
+  );
+}

--- a/src/components/header/HeaderToolbar.tsx
+++ b/src/components/header/HeaderToolbar.tsx
@@ -19,6 +19,8 @@ import {useNavigate} from 'react-router-dom';
 import {useRecoilState} from 'recoil';
 import {CurrentUsernameState} from 'src/atoms/UserState';
 import {GlobalAuthState, logoutUser} from 'src/resources/AuthResource';
+import {addDisplayError} from 'src/resources/ErrorHandling';
+import ErrorModal from '../errors/ErrorModal';
 
 import 'src/components/header/HeaderToolbar.css';
 
@@ -26,6 +28,7 @@ export function HeaderToolbar() {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [currentUsername, setCurrentUsername] =
     useRecoilState(CurrentUsernameState);
+  const [err, setErr] = useState<string>();
 
   const navigate = useNavigate();
 
@@ -42,9 +45,9 @@ export function HeaderToolbar() {
           GlobalAuthState.csrfToken = undefined;
           setCurrentUsername('');
           navigate('/signin');
-        } catch (err: any) {
-          console.error(e);
-          // TODO: Notify user error in signing out
+        } catch (err) {
+          console.error(err);
+          setErr(addDisplayError('Unable to log out', err));
         }
         break;
       default:
@@ -94,34 +97,37 @@ export function HeaderToolbar() {
   };
 
   return (
-    <Toolbar id="toolbar" isFullHeight isStatic>
-      <ToolbarContent>
-        <ToolbarGroup
-          variant="icon-button-group"
-          alignment={{default: 'alignRight'}}
-          spacer={{default: 'spacerNone', md: 'spacerMd'}}
-        >
-          <ToolbarItem spacer={toolbarSpacers}>
-            <Form isHorizontal>
-              <FormGroup
-                label="Current UI"
-                fieldId="horizontal-form-stacked-options"
-              >
-                <Switch
-                  id="header-toolbar-ui-switch"
-                  label="New UI"
-                  labelOff="New UI"
-                  isChecked={isChecked}
-                  onChange={toggleSwitch}
-                />
-              </FormGroup>
-            </Form>
-          </ToolbarItem>
-          <ToolbarItem>
-            {currentUsername ? userDropdown : signInButton}
-          </ToolbarItem>
-        </ToolbarGroup>
-      </ToolbarContent>
-    </Toolbar>
+    <>
+      <ErrorModal error={err} setError={setErr} />
+      <Toolbar id="toolbar" isFullHeight isStatic>
+        <ToolbarContent>
+          <ToolbarGroup
+            variant="icon-button-group"
+            alignment={{default: 'alignRight'}}
+            spacer={{default: 'spacerNone', md: 'spacerMd'}}
+          >
+            <ToolbarItem spacer={toolbarSpacers}>
+              <Form isHorizontal>
+                <FormGroup
+                  label="Current UI"
+                  fieldId="horizontal-form-stacked-options"
+                >
+                  <Switch
+                    id="header-toolbar-ui-switch"
+                    label="New UI"
+                    labelOff="New UI"
+                    isChecked={isChecked}
+                    onChange={toggleSwitch}
+                  />
+                </FormGroup>
+              </Form>
+            </ToolbarItem>
+            <ToolbarItem>
+              {currentUsername ? userDropdown : signInButton}
+            </ToolbarItem>
+          </ToolbarGroup>
+        </ToolbarContent>
+      </Toolbar>
+    </>
   );
 }

--- a/src/components/modals/BulkDeleteModalTemplate.tsx
+++ b/src/components/modals/BulkDeleteModalTemplate.tsx
@@ -19,8 +19,6 @@ import {
   Tr,
 } from '@patternfly/react-table';
 import {useEffect, useState} from 'react';
-import {addDisplayError} from 'src/resources/ErrorHandling';
-import FormError from '../errors/FormError';
 
 export const BulkDeleteModalTemplate = <T,>(
   props: BulkDeleteModalTemplateProps<T>,
@@ -39,7 +37,6 @@ export const BulkDeleteModalTemplate = <T,>(
     page: 1,
     perPage: 10,
   });
-  const [err, setErr] = useState<string>();
 
   const onSearch = (value: string) => {
     setSearchInput(value);
@@ -60,12 +57,7 @@ export const BulkDeleteModalTemplate = <T,>(
   const bulkDelete = async () => {
     // TODO:(harish) Ask UX for Alert msg in case text entered is invalid
     if (confirmDeletionInput === 'confirm') {
-      try {
-        await props.handleBulkDeletion(props.selectedItems);
-      } catch (err) {
-        console.error(err);
-        setErr(addDisplayError('Unable to delete items', err));
-      }
+      await props.handleBulkDeletion(props.selectedItems);
     }
   };
 
@@ -125,7 +117,6 @@ export const BulkDeleteModalTemplate = <T,>(
             </ToolbarItem>
           </ToolbarContent>
         </Toolbar>
-        <FormError message={err} setErr={setErr} />
         <TableComposable aria-label="Simple table" variant="compact">
           <Thead>
             <Tr>

--- a/src/components/modals/CreateRepoModalTemplate.tsx
+++ b/src/components/modals/CreateRepoModalTemplate.tsx
@@ -24,6 +24,7 @@ import ErrorBoundary from 'src/components/errors/ErrorBoundary';
 import FormError from '../errors/FormError';
 import {useRefreshUser} from 'src/hooks/UseRefreshUser';
 import {ExclamationCircleIcon} from '@patternfly/react-icons';
+import {addDisplayError} from 'src/resources/ErrorHandling';
 
 enum visibilityType {
   PUBLIC = 'PUBLIC',
@@ -122,7 +123,7 @@ function CreateRepositoryModal(props: CreateRepositoryModalTemplateProps) {
       props.handleModalToggle();
     } catch (error: any) {
       console.error(error);
-      setErr('Unable to create repository');
+      setErr(addDisplayError('Unable to create repository', error));
     }
   };
 

--- a/src/resources/ErrorHandling.ts
+++ b/src/resources/ErrorHandling.ts
@@ -1,8 +1,77 @@
 import {AxiosError} from 'axios';
 
+// Collects multiple error responses from a bulk operation
+// with error response being mapped to some key
+export class BulkOperationError<T> extends Error {
+  responses: Map<string, T>;
+  constructor(message: string) {
+    super(message);
+    this.responses = new Map<string, T>();
+    Object.setPrototypeOf(this, BulkOperationError.prototype);
+  }
+  addError(key: string, error: T) {
+    this.responses.set(key, error);
+  }
+  getErrors() {
+    return this.responses;
+  }
+}
+
+// Convert error to human readble output
 export function addDisplayError(message: string, error: Error | AxiosError) {
-  // Add user friendly description of error
-  return message + ', ' + error.message + '.';
+  const errorDetails =
+    error instanceof AxiosError ? getErrorMessage(error) : 'client error';
+  return message + ', ' + errorDetails + '.';
+}
+
+interface ErrorResponse {
+  error_message?: string;
+}
+
+// Only handling the codes related to network errors. HTTP based errors
+// will be read from error.response.status. Axios codes left out of list:
+// ERR_BAD_OPTION_VALUE
+// ERR_BAD_OPTION
+// ERR_BAD_RESPONSE
+// ERR_BAD_REQUEST
+// ERR_DEPRECATED
+enum AxiosErrorCode {
+  ERR_FR_TOO_MANY_REDIRECTS = 'ERR_FR_TOO_MANY_REDIRECTS',
+  ERR_NETWORK = 'ERR_NETWORK',
+  ERR_CANCELED = 'ERR_CANCELED',
+  ECONNABORTED = 'ECONNABORTED',
+  ETIMEDOUT = 'ETIMEDOUT',
+}
+
+export function getErrorMessage(error: AxiosError<ErrorResponse>) {
+  if (Object.values(AxiosErrorCode).includes(error.code as AxiosErrorCode)) {
+    return getNetworkError(error.code as AxiosErrorCode);
+  }
+
+  if (error.response.status) {
+    let message = `HTTP${error.response.status}`;
+    if (error.response.data?.error_message) {
+      message = message + ` - ${error.response.data?.error_message}`;
+    }
+    return message;
+  }
+
+  return 'unable to make request';
+}
+
+function getNetworkError(code: AxiosErrorCode) {
+  switch (code) {
+    case AxiosErrorCode.ERR_FR_TOO_MANY_REDIRECTS:
+      return 'too many redirects';
+    case AxiosErrorCode.ERR_NETWORK:
+      return 'connection cannot be made';
+    case AxiosErrorCode.ERR_CANCELED:
+      return 'request cancelled';
+    case AxiosErrorCode.ECONNABORTED:
+      return 'connection aborted';
+    case AxiosErrorCode.ETIMEDOUT:
+      return 'connection timed out';
+  }
 }
 
 export function assertHttpCode(got: number, expected: number) {

--- a/src/routes/OrganizationsList/CreateOrganizationModal.tsx
+++ b/src/routes/OrganizationsList/CreateOrganizationModal.tsx
@@ -4,11 +4,7 @@ import {
   Button,
   Form,
   FormGroup,
-  Text,
   TextInput,
-  TextVariants,
-  Slider,
-  Popover,
 } from '@patternfly/react-core';
 import './css/Organizations.scss';
 import {createOrg} from 'src/resources/OrganisationResource';
@@ -16,6 +12,7 @@ import {isValidEmail} from 'src/libs/utils';
 import {useState} from 'react';
 import FormError from 'src/components/errors/FormError';
 import {useRefreshUser} from 'src/hooks/UseRefreshUser';
+import {addDisplayError} from 'src/resources/ErrorHandling';
 
 export const CreateOrganizationModal = (
   props: CreateOrganizationModalProps,
@@ -43,7 +40,7 @@ export const CreateOrganizationModal = (
       }
     } catch (err) {
       console.error(err);
-      setErr('Unable to create organization');
+      setErr(addDisplayError('Unable to create organization', err));
     }
   };
 

--- a/src/routes/RepositoryDetails/Tags/DeleteModal.tsx
+++ b/src/routes/RepositoryDetails/Tags/DeleteModal.tsx
@@ -1,10 +1,11 @@
 import {Modal, ModalVariant, Button, Label} from '@patternfly/react-core';
 import {useState} from 'react';
-import FormError from 'src/components/errors/FormError';
+import ErrorModal from 'src/components/errors/ErrorModal';
+import {addDisplayError, BulkOperationError} from 'src/resources/ErrorHandling';
 import {bulkDeleteTags} from 'src/resources/TagResource';
 
 export function DeleteModal(props: ModalProps) {
-  const [err, setErr] = useState<string>();
+  const [err, setErr] = useState<string[]>();
   const deleteTags = async () => {
     try {
       const tags = props.selectedTags.map((tag) => ({
@@ -13,59 +14,73 @@ export function DeleteModal(props: ModalProps) {
         tag: tag,
       }));
       await bulkDeleteTags(tags);
+    } catch (err: any) {
+      console.error(err);
+      if (err instanceof BulkOperationError) {
+        const errMessages = [];
+        // TODO: Would like to use for .. of instead of foreach
+        // typescript complains saying we're using version prior to es6?
+        err.getErrors().forEach((error, tag) => {
+          errMessages.push(
+            addDisplayError(`Failed to delete tag ${tag}`, error.error),
+          );
+        });
+        setErr(errMessages);
+      } else {
+        setErr([addDisplayError('Failed to delete tags', err)]);
+      }
+    } finally {
       props.loadTags();
       props.setIsOpen(!props.isOpen);
       props.setSelectedTags([]);
-    } catch (err: any) {
-      console.error(err);
-      // TODO: Add to message the tags that weren't able to be deleted
-      setErr('Unable to delete tags');
     }
   };
   return (
-    <Modal
-      title={`Delete the following tag${
-        props.selectedTags.length > 1 ? 's' : ''
-      }?`}
-      isOpen={props.isOpen}
-      disableFocusTrap={true}
-      key="modal"
-      onClose={() => {
-        props.setIsOpen(!props.isOpen);
-      }}
-      data-testid="delete-tags-modal"
-      variant={ModalVariant.small}
-      actions={[
-        <Button
-          key="cancel"
-          variant="primary"
-          onClick={() => {
-            props.setIsOpen(!props.isOpen);
-          }}
-        >
-          Cancel
-        </Button>,
-        <Button
-          key="modal-action-button"
-          variant="primary"
-          onClick={deleteTags}
-        >
-          Delete
-        </Button>,
-      ]}
-    >
-      <FormError message={err} setErr={setErr} />
-      {props.selectedTags.map((tag) => (
-        <span key={tag}>
-          <Label>{tag}</Label>{' '}
-        </span>
-      ))}
-      {props.selectedTags.length > 1 ? (
-        <div>
-          <b>Note:</b> This operation can take several minutes.
-        </div>
-      ) : null}
-    </Modal>
+    <>
+      <ErrorModal title="Tag deletion failed" error={err} setError={setErr} />
+      <Modal
+        title={`Delete the following tag${
+          props.selectedTags.length > 1 ? 's' : ''
+        }?`}
+        isOpen={props.isOpen}
+        disableFocusTrap={true}
+        key="modal"
+        onClose={() => {
+          props.setIsOpen(!props.isOpen);
+        }}
+        data-testid="delete-tags-modal"
+        variant={ModalVariant.small}
+        actions={[
+          <Button
+            key="cancel"
+            variant="primary"
+            onClick={() => {
+              props.setIsOpen(!props.isOpen);
+            }}
+          >
+            Cancel
+          </Button>,
+          <Button
+            key="modal-action-button"
+            variant="primary"
+            onClick={deleteTags}
+          >
+            Delete
+          </Button>,
+        ]}
+      >
+        {props.selectedTags.map((tag) => (
+          <span key={tag}>
+            <Label>{tag}</Label>{' '}
+          </span>
+        ))}
+        {props.selectedTags.length > 1 ? (
+          <div>
+            <b>Note:</b> This operation can take several minutes.
+          </div>
+        ) : null}
+      </Modal>
+    </>
   );
 }
 

--- a/src/routes/RepositoryDetails/Tags/Tags.tsx
+++ b/src/routes/RepositoryDetails/Tags/Tags.tsx
@@ -80,7 +80,7 @@ export default function Tags(props: TagsProps) {
     loadTags();
   }, []);
 
-  if (!loading && !tags?.length) {
+  if (!loading && !tags?.length && !isErrorString(err)) {
     return (
       <Empty
         title="There are no viewable tags for this repository"

--- a/src/routes/Signin/Signin.tsx
+++ b/src/routes/Signin/Signin.tsx
@@ -14,6 +14,7 @@ import axios, {getCsrfToken} from 'src/libs/axios';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import {AxiosError} from 'axios';
 import './Signin.css';
+import {addDisplayError} from 'src/resources/ErrorHandling';
 
 export function Signin() {
   const [username, setUsername] = useState('');
@@ -45,15 +46,16 @@ export function Signin() {
         setErr('Invalid login credentials');
       }
     } catch (err) {
-      console.error(err);
-      if (
+      const authErr =
         err instanceof AxiosError &&
         err.response &&
-        err.response.status === 403
-      ) {
+        err.response.status === 403;
+      if (authErr && err.response.data.invalidCredentials) {
+        setErr('Invalid login credentials');
+      } else if (authErr) {
         setErr('CSRF token expired - please refresh');
       } else {
-        setErr('Unable to connect to server.');
+        setErr(addDisplayError('Unable to sign in', err));
       }
     }
   };

--- a/src/routes/StandaloneMain.tsx
+++ b/src/routes/StandaloneMain.tsx
@@ -14,10 +14,10 @@ import {useEffect, useState} from 'react';
 import {getUser} from 'src/resources/UserResource';
 import {useSetRecoilState} from 'recoil';
 import {CurrentUsernameState} from 'src/atoms/UserState';
-import {isErrorString} from 'src/resources/ErrorHandling';
 import ErrorBoundary from 'src/components/errors/ErrorBoundary';
 import PageLoadError from 'src/components/errors/PageLoadError';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
+import SiteUnavailableError from 'src/components/errors/SiteUnavailableError';
 
 const NavigationRoutes = [
   {
@@ -44,7 +44,7 @@ const NavigationRoutes = [
 
 export function StandaloneMain() {
   const setCurrentUsername = useSetRecoilState(CurrentUsernameState);
-  const [err, setErr] = useState<string>();
+  const [err, setErr] = useState<boolean>();
   const quayConfig = useQuayConfig();
 
   useEffect(() => {
@@ -60,12 +60,12 @@ export function StandaloneMain() {
         setCurrentUsername(user.username);
       } catch (err) {
         console.error(err);
-        setErr('Unable to load page');
+        setErr(true);
       }
     })();
   }, []);
   return (
-    <ErrorBoundary hasError={isErrorString(err)} fallback={<PageLoadError />}>
+    <ErrorBoundary hasError={err} fallback={<SiteUnavailableError />}>
       <Page
         header={<QuayHeader />}
         sidebar={<QuaySidebar />}


### PR DESCRIPTION
Implements the following changes:
- React suspense moved to respository and orgnazation components, fixes choppy reload of screen
- Support for catching individual errors during bulk deletion
- Adding detail to user facing error messages

**Testing**
The mock API cannot be used to properly test errors since it does not return a real `AxiosError`. Editing the Quay backend to return 500 (`return "", 500`) for the relevant endpoints or shutting down the backend completely allows for more accurate errors.