### PR TITLE
use QuayConfig to render the domain for fetch tags popover (PROJQUAY-4340)

### DIFF
--- a/src/routes/RepositoryDetails/Tags/TablePopover.tsx
+++ b/src/routes/RepositoryDetails/Tags/TablePopover.tsx
@@ -8,15 +8,18 @@ import {
   Text,
   Tooltip,
 } from '@patternfly/react-core';
-import {getDomain} from 'src/routes/NavigationPath';
-import {useState} from 'react';
 import {useRecoilState} from 'recoil';
 import {currentOpenPopoverState} from 'src/atoms/TagListState';
+import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 
 export default function TablePopover(props: TablePopoverProps) {
   const [currentOpenPopover, setCurrentOpenPopover] = useRecoilState(
     currentOpenPopoverState,
   );
+
+  const config = useQuayConfig();
+  const domain = config?.config.SERVER_HOSTNAME;
+
   return (
     <Popover
       isVisible={currentOpenPopover === props.tag}
@@ -36,7 +39,7 @@ export default function TablePopover(props: TablePopoverProps) {
             hoverTip="Copy"
             clickTip="Copied"
           >
-            podman pull {getDomain()}/{props.org}/{props.repo}:{props.tag}
+            podman pull {domain}/{props.org}/{props.repo}:{props.tag}
           </ClipboardCopy>
           <br />
           <Text style={{fontWeight: 'bold'}}>Podman Pull (By Digest)</Text>
@@ -46,7 +49,7 @@ export default function TablePopover(props: TablePopoverProps) {
             hoverTip="Copy"
             clickTip="Copied"
           >
-            podman pull {getDomain()}/{props.org}/{props.repo}@{props.digest}
+            podman pull {domain}/{props.org}/{props.repo}@{props.digest}
           </ClipboardCopy>
           <br />
           <Text style={{fontWeight: 'bold'}}>Docker Pull (By Tag)</Text>
@@ -56,7 +59,7 @@ export default function TablePopover(props: TablePopoverProps) {
             hoverTip="Copy"
             clickTip="Copied"
           >
-            docker pull {getDomain()}/{props.org}/{props.repo}:{props.tag}
+            docker pull {domain}/{props.org}/{props.repo}:{props.tag}
           </ClipboardCopy>
           <br />
           <Text style={{fontWeight: 'bold'}}>Docker Pull (By Digest)</Text>
@@ -66,7 +69,7 @@ export default function TablePopover(props: TablePopoverProps) {
             hoverTip="Copy"
             clickTip="Copied"
           >
-            docker pull {getDomain()}/{props.org}/{props.repo}@{props.digest}
+            docker pull {domain}/{props.org}/{props.repo}@{props.digest}
           </ClipboardCopy>
         </div>
       }


### PR DESCRIPTION
uses quay config to set the correct domain
<img width="502" alt="image" src="https://user-images.githubusercontent.com/55854/187752153-f1390a0b-3e67-4c36-beff-a6c5e2c88d56.png">