### PR TITLE
Changing Ellipsis to More Actions button (PROJQUAY-4342)

### DIFF
--- a/src/components/toolbar/Kebab.tsx
+++ b/src/components/toolbar/Kebab.tsx
@@ -1,19 +1,19 @@
-import {Dropdown, KebabToggle} from '@patternfly/react-core';
+import {Dropdown, DropdownToggle} from '@patternfly/react-core';
 import * as React from 'react';
-import {DropdownItemProps} from '@patternfly/react-core/dist/esm/components/Dropdown/DropdownItem';
 
 export function Kebab(props: KebabProps) {
   return (
     <Dropdown
       onSelect={() => props.setKebabOpen(!props.isKebabOpen)}
       toggle={
-        <KebabToggle
+        <DropdownToggle
           onToggle={() => props.setKebabOpen(!props.isKebabOpen)}
           id="toggle-id-6"
-        />
+        >
+          More Actions
+        </DropdownToggle>
       }
       isOpen={props.isKebabOpen}
-      isPlain
       dropdownItems={props.kebabItems}
     />
   );

--- a/src/routes/OrganizationsList/OrganizationsList.tsx
+++ b/src/routes/OrganizationsList/OrganizationsList.tsx
@@ -69,6 +69,7 @@ function PageContent() {
   useEffect(() => {
     // Get latest organizations
     refreshUser();
+    setSelectedOrganization([]);
     setLoading(false);
   }, []);
   // TODO: Using mock values here - remove in the future?


### PR DESCRIPTION
Fixes: [Selections still active, after navigation to new area](https://issues.redhat.com/browse/PROJQUAY-4349) and [In multi-select, replace ellipsis with text "More Actions"](https://issues.redhat.com/browse/PROJQUAY-4342)


<img width="1909" alt="Screen Shot 2022-08-31 at 4 17 11 PM" src="https://user-images.githubusercontent.com/11522230/187774651-d19812f0-3e46-49b6-84a0-4afbf8293da2.png">
<img width="1911" alt="Screen Shot 2022-08-31 at 4 17 23 PM" src="https://user-images.githubusercontent.com/11522230/187774664-98e84d53-3589-45de-b2dd-86bb60c367ee.png">
