### PR TITLE
errors: Surface not found issues (PROJQUAY-4386)

### DIFF
--- a/src/resources/ErrorHandling.ts
+++ b/src/resources/ErrorHandling.ts
@@ -20,7 +20,7 @@ export class BulkOperationError<T> extends Error {
 // Convert error to human readble output
 export function addDisplayError(message: string, error: Error | AxiosError) {
   const errorDetails =
-    error instanceof AxiosError ? getErrorMessage(error) : 'client error';
+    error instanceof AxiosError ? getErrorMessage(error) : error.message;
   return message + ', ' + errorDetails + '.';
 }
 

--- a/src/routes/RepositoriesList/RepositoriesList.tsx
+++ b/src/routes/RepositoriesList/RepositoriesList.tsx
@@ -252,7 +252,7 @@ function RepoListContent(props: RepoListContentProps) {
         setLoading(false);
       } catch (err) {
         console.error(err);
-        props.setLoadingErr(addDisplayError('Unable to get repositores', err));
+        props.setLoadingErr(addDisplayError('Unable to get repositories', err));
       }
     }
   }

--- a/src/routes/RepositoryDetails/Tags/Tags.tsx
+++ b/src/routes/RepositoryDetails/Tags/Tags.tsx
@@ -105,23 +105,23 @@ export default function Tags(props: TagsProps) {
   return (
     <Page>
       <PageSection variant={PageSectionVariants.light}>
-        <TagsToolbar
-          organization={props.organization}
-          repository={props.repository}
-          tagCount={filteredTags.length}
-          loadTags={loadTags}
-          TagList={tags}
-          paginatedTags={paginatedTags}
-          perPage={perPage}
-          page={page}
-          setPage={setPage}
-          setPerPage={setPerPage}
-          selectTag={selectTag}
-        ></TagsToolbar>
         <ErrorBoundary
           hasError={isErrorString(err)}
           fallback={<RequestError message={err} />}
         >
+          <TagsToolbar
+            organization={props.organization}
+            repository={props.repository}
+            tagCount={filteredTags.length}
+            loadTags={loadTags}
+            TagList={tags}
+            paginatedTags={paginatedTags}
+            perPage={perPage}
+            page={page}
+            setPage={setPage}
+            setPerPage={setPerPage}
+            selectTag={selectTag}
+          />
           <Table
             org={props.organization}
             repo={props.repository}

--- a/src/routes/TagDetails/Packages/Packages.tsx
+++ b/src/routes/TagDetails/Packages/Packages.tsx
@@ -8,7 +8,7 @@ import {
 import {isErrorString} from 'src/resources/ErrorHandling';
 import RequestError from 'src/components/errors/RequestError';
 
-export function Packages(props: PackagesProps) {
+export function Packages() {
   const data = useRecoilValue(SecurityDetailsState);
   const error = useRecoilValue(SecurityDetailsErrorState);
 
@@ -30,10 +30,4 @@ export function Packages(props: PackagesProps) {
       <PackagesTable features={features} />
     </>
   );
-}
-
-interface PackagesProps {
-  org: string;
-  repo: string;
-  digest: string;
 }

--- a/src/routes/TagDetails/SecurityReport/SecurityReport.tsx
+++ b/src/routes/TagDetails/SecurityReport/SecurityReport.tsx
@@ -8,7 +8,7 @@ import {
 import {isErrorString} from 'src/resources/ErrorHandling';
 import RequestError from 'src/components/errors/RequestError';
 
-export default function SecurityReport(props: SecurityReportProps) {
+export default function SecurityReport() {
   const data = useRecoilValue(SecurityDetailsState);
   const error = useRecoilValue(SecurityDetailsErrorState);
 
@@ -30,10 +30,4 @@ export default function SecurityReport(props: SecurityReportProps) {
       <SecurityReportTable features={features} />
     </>
   );
-}
-
-interface SecurityReportProps {
-  org: string;
-  repo: string;
-  digest: string;
 }

--- a/src/routes/TagDetails/TagDetails.tsx
+++ b/src/routes/TagDetails/TagDetails.tsx
@@ -19,8 +19,10 @@ import {
   ManifestByDigestResponse,
   Manifest,
 } from 'src/resources/TagResource';
-import {addDisplayError} from 'src/resources/ErrorHandling';
+import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
 import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
+import ErrorBoundary from 'src/components/errors/ErrorBoundary';
+import RequestError from 'src/components/errors/RequestError';
 
 export default function TagDetails() {
   const [searchParams] = useSearchParams();
@@ -110,14 +112,19 @@ export default function TagDetails() {
           setArch={setArchitecture}
           render={tagDetails.is_manifest_list}
         />
-        <TagTabs
-          org={org}
-          repo={repo}
-          tag={tagDetails}
-          size={size}
-          digest={digest}
-          err={err}
-        />
+        <ErrorBoundary
+          hasError={isErrorString(err)}
+          fallback={<RequestError message={err} />}
+        >
+          <TagTabs
+            org={org}
+            repo={repo}
+            tag={tagDetails}
+            size={size}
+            digest={digest}
+            err={err}
+          />
+        </ErrorBoundary>
       </PageSection>
     </Page>
   );

--- a/src/routes/TagDetails/TagDetailsTabs.tsx
+++ b/src/routes/TagDetails/TagDetailsTabs.tsx
@@ -38,44 +38,25 @@ export default function TagTabs(props: TagTabsProps) {
         eventKey={TabIndex.Details}
         title={<TabTitleText>Details</TabTitleText>}
       >
-        <ErrorBoundary
-          hasError={isErrorString(props.err)}
-          fallback={<RequestError message={props.err} />}
-        >
-          <Details
-            org={props.org}
-            repo={props.repo}
-            tag={props.tag}
-            size={props.size}
-            digest={props.digest}
-          />
-        </ErrorBoundary>
+        <Details
+          org={props.org}
+          repo={props.repo}
+          tag={props.tag}
+          size={props.size}
+          digest={props.digest}
+        />
       </Tab>
       <Tab
         eventKey={TabIndex.SecurityReport}
         title={<TabTitleText>Security Report</TabTitleText>}
       >
-        <ErrorBoundary
-          hasError={isErrorString(props.err)}
-          fallback={<RequestError message={props.err} />}
-        >
-          <SecurityReport
-            org={props.org}
-            repo={props.repo}
-            digest={props.digest}
-          />
-        </ErrorBoundary>
+        <SecurityReport />
       </Tab>
       <Tab
         eventKey={TabIndex.Packages}
         title={<TabTitleText>Packages</TabTitleText>}
       >
-        <ErrorBoundary
-          hasError={isErrorString(props.err)}
-          fallback={<RequestError message={props.err} />}
-        >
-          <Packages org={props.org} repo={props.repo} digest={props.digest} />
-        </ErrorBoundary>
+        <Packages />
       </Tab>
     </Tabs>
   );


### PR DESCRIPTION
Refactoring error handling to surface resource not found errors for non existent tags and repositories. 
Currently does not handle organizations not found due to more API call's being required.
