### PR TITLE
Fix browser caching / redirect (PROJQUAY-4423)

### DIFF
--- a/src/components/header/HeaderToolbar.tsx
+++ b/src/components/header/HeaderToolbar.tsx
@@ -92,7 +92,11 @@ export function HeaderToolbar() {
     // Reload page and trigger patternfly cookie removal
     const protocol = window.location.protocol;
     const host = window.location.host;
-    window.location.replace(`${protocol}//${host}/angular`);
+    const path = 'angular';
+
+    // Add a random arg so nginx redirect to / doesn't get cached by browser
+    const randomArg = '?_=' + new Date().getTime();
+    window.location.replace(`${protocol}//${host}/${path}/${randomArg}`);
   };
   const toolbarSpacers = {
     default: 'spacerNone',


### PR DESCRIPTION
This is the first part of a two part PR. Second PR needs to be opened in quay repo to allow nginx to pass query args. 

* Prevents browser from caching nginx redirect to `/` by passing query args in replace request. 