### PR TITLE
Refactoring organization and repository list pages

### DIFF
--- a/src/atoms/OrganizationListState.ts
+++ b/src/atoms/OrganizationListState.ts
@@ -1,0 +1,6 @@
+import {atom} from 'recoil';
+
+export const refreshPageState = atom({
+  key: 'refreshOrgPageState',
+  default: 0,
+});

--- a/src/atoms/RepositoryState.ts
+++ b/src/atoms/RepositoryState.ts
@@ -14,3 +14,8 @@ export const searchRepoState = atom<SearchState>({
     field: ColumnNames.name,
   },
 });
+
+export const refreshPageState = atom({
+  key: 'refreshRepoPageState',
+  default: 0,
+});

--- a/src/atoms/UserState.ts
+++ b/src/atoms/UserState.ts
@@ -1,29 +1,11 @@
-import {atom, selector} from 'recoil';
-import {IUserResource} from 'src/resources/UserResource';
+import {atom} from 'recoil';
 import {IOrganization} from 'src/resources/OrganizationResource';
-import {fetchUser} from 'src/resources/UserResource';
 import ColumnNames from 'src/routes/OrganizationsList/ColumnNames';
 import {SearchState} from 'src/components/toolbar/SearchTypes';
-
-// Request ID is used to refresh userState via the API.
-// Updating UserRequestId get's the latest contents of
-// the user state.
-export const UserRequestId = atom({
-  key: 'userRequestId',
-  default: 0,
-});
 
 export const CurrentUsernameState = atom({
   key: 'currentUsernameState',
   default: '',
-});
-
-export const UserState = selector<IUserResource | undefined>({
-  key: 'userState',
-  get: async ({get}) => {
-    get(UserRequestId); // Add dep on UserRequestId to allow refreshes
-    return await fetchUser();
-  },
 });
 
 export const selectedOrgsState = atom<IOrganization[]>({

--- a/src/components/LoadingPage.tsx
+++ b/src/components/LoadingPage.tsx
@@ -7,6 +7,8 @@ import {
   Title,
   Spinner,
   Bullseye,
+  PageSectionVariants,
+  PageSection,
 } from '@patternfly/react-core';
 
 export function LoadingPage(props: {
@@ -16,20 +18,22 @@ export function LoadingPage(props: {
   secondaryActions?: React.ReactNode;
 }) {
   return (
-    <Bullseye>
-      <EmptyState>
-        <EmptyStateIcon variant="container" component={Spinner} />
-        <div>
-          <Title size="lg" headingLevel="h4">
-            {props.title ?? 'Loading'}
-          </Title>
-          <EmptyStateBody>{props.message}</EmptyStateBody>
-        </div>
-        {props.primaryAction}
-        <EmptyStateSecondaryActions>
-          {props.secondaryActions}
-        </EmptyStateSecondaryActions>
-      </EmptyState>
-    </Bullseye>
+    <PageSection variant={PageSectionVariants.light}>
+      <Bullseye>
+        <EmptyState>
+          <EmptyStateIcon variant="container" component={Spinner} />
+          <div>
+            <Title size="lg" headingLevel="h4">
+              {props.title ?? 'Loading'}
+            </Title>
+            <EmptyStateBody>{props.message}</EmptyStateBody>
+          </div>
+          {props.primaryAction}
+          <EmptyStateSecondaryActions>
+            {props.secondaryActions}
+          </EmptyStateSecondaryActions>
+        </EmptyState>
+      </Bullseye>
+    </PageSection>
   );
 }

--- a/src/components/errors/RequestError.tsx
+++ b/src/components/errors/RequestError.tsx
@@ -4,13 +4,14 @@ import {
   EmptyStateBody,
   EmptyStateIcon,
   PageSection,
+  PageSectionVariants,
   Title,
 } from '@patternfly/react-core';
 import {ExclamationTriangleIcon} from '@patternfly/react-icons';
 
 export default function RequestError(props: RequestErrorProps) {
   return (
-    <PageSection>
+    <PageSection variant={PageSectionVariants.light}>
       <EmptyState variant="full">
         <EmptyStateIcon icon={ExclamationTriangleIcon} />
         <Title headingLevel="h1" size="lg">

--- a/src/components/modals/ConfirmationModal.tsx
+++ b/src/components/modals/ConfirmationModal.tsx
@@ -3,11 +3,11 @@ import {Modal, ModalVariant, Button} from '@patternfly/react-core';
 import {useState} from 'react';
 import FormError from 'src/components/errors/FormError';
 import {addDisplayError} from 'src/resources/ErrorHandling';
-import {useRefreshUser} from 'src/hooks/UseRefreshUser';
+import {useRefreshRepoList} from 'src/hooks/UseRefreshPage';
 
 export function ConfirmationModal(props: ConfirmationModalProps) {
   const [err, setErr] = useState<string>();
-  const refreshUser = useRefreshUser();
+  const refresh = useRefreshRepoList();
 
   const changeVisibility = async () => {
     const visibility = props.makePublic ? 'public' : 'private';
@@ -20,7 +20,7 @@ export function ConfirmationModal(props: ConfirmationModalProps) {
           return setRepositoryVisibility(ls[0], ls[1], visibility);
         }),
       );
-      refreshUser();
+      refresh();
       props.toggleModal();
       props.selectAllRepos(false);
     } catch (error: any) {

--- a/src/components/modals/CreateRepoModalTemplate.tsx
+++ b/src/components/modals/CreateRepoModalTemplate.tsx
@@ -12,64 +12,30 @@ import {
   Flex,
   FlexItem,
 } from '@patternfly/react-core';
-import {useRecoilValue} from 'recoil';
-import {UserState} from 'src/atoms/UserState';
 import {
   createNewRepository,
   IRepository,
 } from 'src/resources/RepositoryResource';
 import {useRef, useState} from 'react';
-import ErrorBoundary from 'src/components/errors/ErrorBoundary';
 import FormError from 'src/components/errors/FormError';
-import {useRefreshUser} from 'src/hooks/UseRefreshUser';
 import {ExclamationCircleIcon} from '@patternfly/react-icons';
 import {addDisplayError} from 'src/resources/ErrorHandling';
-import {IUserResource} from 'src/resources/UserResource';
+import {IOrganization} from 'src/resources/OrganizationResource';
+import {useRefreshRepoList} from 'src/hooks/UseRefreshPage';
 
 enum visibilityType {
   PUBLIC = 'PUBLIC',
   PRIVATE = 'PRIVATE',
 }
 
-// Attempt to render modal content, fallback to error
-// display if failure
 export default function CreateRepositoryModalTemplate(
   props: CreateRepositoryModalTemplateProps,
 ) {
-  return (
-    <ErrorBoundary fallback={ErrorModal}>
-      <CreateRepositoryModal {...props} />
-    </ErrorBoundary>
-  );
-}
-
-function ErrorModal(props: ErrorModalProps) {
-  return (
-    <Modal
-      title="Loading Failure"
-      variant={ModalVariant.large}
-      isOpen={props.isOpen}
-      onClose={props.toggle}
-      actions={[
-        <Button key="cancel" variant="link" onClick={props.toggle}>
-          Cancel
-        </Button>,
-      ]}
-    >
-      <div>
-        Error loading create repository form. Please close and try again.
-      </div>
-    </Modal>
-  );
-}
-
-function CreateRepositoryModal(props: CreateRepositoryModalTemplateProps) {
   if (!props.isModalOpen) {
     return null;
   }
-  const userState: IUserResource = useRecoilValue(UserState);
   const [err, setErr] = useState<string>();
-  const refreshUser = useRefreshUser();
+  const refresh = useRefreshRepoList();
 
   const [currentOrganization, setCurrentOrganization] = useState({
     // For org scoped view, the name is set current org and for Repository list view,
@@ -119,7 +85,7 @@ function CreateRepositoryModal(props: CreateRepositoryModalTemplateProps) {
         newRepository.description,
         'image',
       );
-      refreshUser();
+      refresh();
       props.handleModalToggle();
     } catch (error: any) {
       console.error(error);
@@ -137,9 +103,9 @@ function CreateRepositoryModal(props: CreateRepositoryModalTemplateProps) {
   // namespace list includes both the orgs list and the user namespace
   const namespaceSelectionList = () => {
     const userSelection = (
-      <SelectOption value={userState.username}></SelectOption>
+      <SelectOption key={props.username} value={props.username}></SelectOption>
     );
-    const orgsSelectionList = userState.organizations.map((orgs, idx) => (
+    const orgsSelectionList = props.organizations.map((orgs, idx) => (
       <SelectOption key={idx} value={orgs.name}></SelectOption>
     ));
 
@@ -272,6 +238,8 @@ interface CreateRepositoryModalTemplateProps {
   handleModalToggle?: () => void;
   orgName?: string;
   updateListHandler: (value: IRepository) => void;
+  username: string;
+  organizations: IOrganization[];
 }
 
 interface ErrorModalProps {

--- a/src/hooks/UseRefreshPage.ts
+++ b/src/hooks/UseRefreshPage.ts
@@ -1,0 +1,13 @@
+import {useSetRecoilState} from 'recoil';
+import {refreshPageState as orgListRefreshPageState} from 'src/atoms/OrganizationListState';
+import {refreshPageState as repoListRefreshPageState} from 'src/atoms/RepositoryState';
+
+export function userRefreshOrgList() {
+  const setRefreshOrgList = useSetRecoilState(orgListRefreshPageState);
+  return () => setRefreshOrgList((index) => index + 1);
+}
+
+export function useRefreshRepoList() {
+  const setRefreshRepoList = useSetRecoilState(repoListRefreshPageState);
+  return () => setRefreshRepoList((index) => index + 1);
+}

--- a/src/hooks/UseRefreshUser.ts
+++ b/src/hooks/UseRefreshUser.ts
@@ -1,8 +1,0 @@
-import {useSetRecoilState} from 'recoil';
-import {UserRequestId} from 'src/atoms/UserState';
-
-// Updates UserRequestId to refresh cache for UserState,
-export function useRefreshUser() {
-  const setUserRequestId = useSetRecoilState(UserRequestId);
-  return () => setUserRequestId((requestId) => requestId + 1);
-}

--- a/src/routes/OrganizationsList/CreateOrganizationModal.tsx
+++ b/src/routes/OrganizationsList/CreateOrganizationModal.tsx
@@ -11,8 +11,8 @@ import {createOrg} from 'src/resources/OrganizationResource';
 import {isValidEmail} from 'src/libs/utils';
 import {useState} from 'react';
 import FormError from 'src/components/errors/FormError';
-import {useRefreshUser} from 'src/hooks/UseRefreshUser';
 import {addDisplayError} from 'src/resources/ErrorHandling';
+import {userRefreshOrgList} from 'src/hooks/UseRefreshPage';
 
 export const CreateOrganizationModal = (
   props: CreateOrganizationModalProps,
@@ -21,7 +21,7 @@ export const CreateOrganizationModal = (
   const [organizationEmail, setOrganizationEmail] = useState('');
   const [invalidEmailFlag, setInvalidEmailFlag] = useState(false);
   const [err, setErr] = useState<string>();
-  const refreshUser = useRefreshUser();
+  const refresh = userRefreshOrgList();
 
   const handleNameInputChange = (value: any) => {
     setOrganizationName(value);
@@ -36,7 +36,7 @@ export const CreateOrganizationModal = (
       const response = await createOrg(organizationName, organizationEmail);
       props.handleModalToggle();
       if (response === 'Created') {
-        refreshUser();
+        refresh();
       }
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
### Motivation

We currently pull `UserState` via a recoil selector. This raises the following issues:
- Async recoil selectors are required to be idempotent, they cache responses based on the parameters passed in. This means you cannot get the latest values unless completely reloading the page. 
- The function recoil recommends for invalidating that cache is currently marked as `UNSTABLE`.
    - We currently use the other method for invalidating the cache, adding another atom to the UserState selector. By updating the atom it invalidates the cache, retries the request, and re-renders all components dependent on UserState. This is error prone and somewhat complicated.
- Handling loading and error states using async recoil selectors differs from requests made directly in the component. Recoil requires using `Suspense` and `ErrorBoundary` components while requests in the component requires `loading` and `error` `useState`'s. Having loading and error states handled two different ways significantly complicates components.

### Changes made

Changes were only required to the Org and Repo list pages.

- Remove the `UserState` selector and call the user endpoint directly in the component. 
- Remove `Suspense` and `ErrorBoundary` components, instead use the existing `loading` and `error` state.
- Have the initial data request be dependent on a `refreshPageState` atom. When ever the latest data needs to be retrieved, another component can increment this atom. 
    - The `src/hooks/UseRefreshPage.ts` hooks provides functions that when called increment this value and refresh the data. Creates an easy API: `const refresh = useRefreshRepoList(); refresh();`
