### PR TITLE
Adding 404 default path

### DIFF
--- a/src/components/errors/404.tsx
+++ b/src/components/errors/404.tsx
@@ -4,24 +4,27 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
+  Page,
   PageSection,
   Title,
 } from '@patternfly/react-core';
 import {ExclamationTriangleIcon} from '@patternfly/react-icons';
 
-function NotFound() {
+export default function NotFound() {
   return (
-    <PageSection>
-      <EmptyState variant="full">
-        <EmptyStateIcon icon={ExclamationTriangleIcon} />
-        <Title headingLevel="h1" size="lg">
-          404 Page not found
-        </Title>
-        <EmptyStateBody>
-          We didn&apos;t find a page that matches the address you navigated to.
-        </EmptyStateBody>
-        <Button title="Home" />
-      </EmptyState>
-    </PageSection>
+    <Page>
+      <PageSection>
+        <EmptyState variant="full">
+          <EmptyStateIcon icon={ExclamationTriangleIcon} />
+          <Title headingLevel="h1" size="lg">
+            404 Page not found
+          </Title>
+          <EmptyStateBody>
+            We didn&apos;t find a page that matches the address you navigated
+            to.
+          </EmptyStateBody>
+        </EmptyState>
+      </PageSection>
+    </Page>
   );
 }

--- a/src/routes/StandaloneMain.tsx
+++ b/src/routes/StandaloneMain.tsx
@@ -15,9 +15,9 @@ import {fetchUser} from 'src/resources/UserResource';
 import {useSetRecoilState} from 'recoil';
 import {CurrentUsernameState} from 'src/atoms/UserState';
 import ErrorBoundary from 'src/components/errors/ErrorBoundary';
-import PageLoadError from 'src/components/errors/PageLoadError';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
 import SiteUnavailableError from 'src/components/errors/SiteUnavailableError';
+import NotFound from 'src/components/errors/404';
 
 const NavigationRoutes = [
   {
@@ -78,6 +78,7 @@ export function StandaloneMain() {
           {NavigationRoutes.map(({path, Component}, key) => (
             <Route path={path} key={key} element={Component} />
           ))}
+          <Route path="*" element={<NotFound />} />
         </Routes>
         <Outlet />
       </Page>


### PR DESCRIPTION
Currently paths with no matching route render an empty page. This defaults on non matching routes to render a 404 page. 

**How to test**
- All valid paths must render existing components
- Any non-matching paths should render the 404 page