### PR TITLE
Fixed alignment of logo

### DIFF
--- a/src/routes/Signin/Signin.tsx
+++ b/src/routes/Signin/Signin.tsx
@@ -91,7 +91,7 @@ export function Signin() {
 
   return (
     <LoginPage
-      className={'pdf-u-background-color-100 pf-u-text-align-center'}
+      className={'pdf-u-background-color-100 pf-u-text-align-left'}
       brandImgSrc={logoUrl}
       brandImgAlt="Red Hat Quay"
       backgroundImgSrc="assets/images/rh_login.jpeg"


### PR DESCRIPTION
**Text and logo should be aligned left**

<img width="1238" alt="image" src="https://user-images.githubusercontent.com/91554933/193369365-fb2964fa-bb0c-4df5-a2ad-cf19187b93d8.png">

[**Patternfly Login Page**
](https://www.patternfly.org/v4/components/login-page)

Before/currently as of 9/30 18:35 (text and logo centered)
<img width="1347" alt="image" src="https://user-images.githubusercontent.com/91554933/193369419-e68ac76d-0526-4559-9f51-87392052c17f.png">

