### PR TITLE
Fixing size computation, refactor architecture select (PROJQUAY-4532)

### DIFF
--- a/src/components/Table/ImageSize.tsx
+++ b/src/components/Table/ImageSize.tsx
@@ -1,0 +1,56 @@
+import {Skeleton} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import {
+  getManifestByDigest,
+  ManifestByDigestResponse,
+} from 'src/resources/TagResource';
+import prettyBytes from 'pretty-bytes';
+
+export default function ImageSize(props: ImageSizeProps) {
+  const [size, setSize] = useState<number>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [err, setErr] = useState<boolean>(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const manifestResp: ManifestByDigestResponse =
+          await getManifestByDigest(props.org, props.repo, props.digest);
+        const calculatedSizeMesnifestResp = manifestResp.layers
+          ? manifestResp.layers.reduce(
+              (prev, curr) => prev + curr.compressed_size,
+              0,
+            )
+          : 0;
+        setSize(calculatedSizeMesnifestResp);
+      } catch (err) {
+        setErr(true);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [props.digest]);
+
+  if (loading) {
+    return <Skeleton />;
+  }
+  if (err) {
+    return <>Error</>;
+  }
+
+  // Behavior based on old UI
+  if (size === 0) {
+    return <>Unknown</>;
+  }
+
+  return <>{prettyBytes(size)}</>;
+}
+
+interface ImageSizeProps {
+  org: string;
+  repo: string;
+  digest: string;
+  // TODO: Add in option to provide an already existing manifest,
+  //   remove the need to make the call again.
+  // manifest?: Manifest;
+}

--- a/src/resources/TagResource.ts
+++ b/src/resources/TagResource.ts
@@ -25,17 +25,26 @@ export interface ManifestList {
   mediaType: string;
   manifests: Manifest[];
 }
+
 export interface Manifest {
   mediaType: string;
   size: number;
   digest: string;
   platform: Platform;
   security: SecurityDetailsResponse;
+  layers: Layer[];
 }
+
+export interface Layer {
+  size: number;
+}
+
 export interface Platform {
   architecture: string;
   os: string;
-  features: string[];
+  features?: string[];
+  variant?: string;
+  'os.version'?: string;
 }
 
 export interface LabelsResponse {

--- a/src/routes/TagDetails/Details/Details.tsx
+++ b/src/routes/TagDetails/Details/Details.tsx
@@ -16,6 +16,7 @@ import {Tag} from 'src/resources/TagResource';
 import {formatDate} from 'src/libs/utils';
 import Labels from 'src/components/labels/Labels';
 import SecurityDetails from 'src/routes/RepositoryDetails/Tags/SecurityDetails';
+import ImageSize from 'src/components/Table/ImageSize';
 
 export default function Details(props: DetailsProps) {
   return (
@@ -83,8 +84,12 @@ export default function Details(props: DetailsProps) {
           <DescriptionListGroup data-testid="size">
             <DescriptionListTerm>Size</DescriptionListTerm>
             <DescriptionListDescription>
-              {props.size ? (
-                prettyBytes(props.size)
+              {props.digest != '' ? (
+                <ImageSize
+                  org={props.org}
+                  repo={props.repo}
+                  digest={props.digest}
+                />
               ) : (
                 <Skeleton width="100%"></Skeleton>
               )}
@@ -104,11 +109,11 @@ export default function Details(props: DetailsProps) {
           <DescriptionListGroup data-testid="labels">
             <DescriptionListTerm>Labels</DescriptionListTerm>
             <DescriptionListDescription>
-              {props.digest !== '' ? (
+              {props.tag.manifest_digest !== '' ? (
                 <Labels
                   org={props.org}
                   repo={props.repo}
-                  digest={props.digest}
+                  digest={props.tag.manifest_digest}
                 />
               ) : (
                 <Skeleton width="100%"></Skeleton>
@@ -134,6 +139,5 @@ type DetailsProps = {
   tag: Tag;
   org: string;
   repo: string;
-  size: number;
   digest: string;
 };

--- a/src/routes/TagDetails/TagDetailsArchSelect.tsx
+++ b/src/routes/TagDetails/TagDetailsArchSelect.tsx
@@ -6,6 +6,7 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 import {useState} from 'react';
+import {Manifest} from 'src/resources/TagResource';
 
 export default function ArchSelect(props: ArchSelectProps) {
   if (!props.render) return null;
@@ -22,16 +23,19 @@ export default function ArchSelect(props: ArchSelectProps) {
           onToggle={() => {
             setIsSelectOpen(!isSelectOpen);
           }}
-          onSelect={(e, arch) => {
-            props.setArch(arch as string);
+          onSelect={(e, digest) => {
+            props.setDigest(digest as string);
             setIsSelectOpen(false);
           }}
-          selections={props.arch}
+          selections={props.digest}
           isOpen={isSelectOpen}
           data-testid="arch-select"
         >
-          {props.options.map((arch, index) => (
-            <SelectOption key={index} value={arch} />
+          {props.options.map((manifest, index) => (
+            <SelectOption key={index} value={manifest.digest}>
+              {' '}
+              {`${manifest.platform.os} on ${manifest.platform.architecture}`}{' '}
+            </SelectOption>
           ))}
         </Select>
       </FlexItem>
@@ -40,8 +44,8 @@ export default function ArchSelect(props: ArchSelectProps) {
 }
 
 type ArchSelectProps = {
-  arch: string;
-  options: string[];
-  setArch: (arch: string) => void;
+  digest: string;
+  options: Manifest[];
+  setDigest: (digest: string) => void;
   render: boolean;
 };

--- a/src/routes/TagDetails/TagDetailsTabs.tsx
+++ b/src/routes/TagDetails/TagDetailsTabs.tsx
@@ -42,7 +42,6 @@ export default function TagTabs(props: TagTabsProps) {
           org={props.org}
           repo={props.repo}
           tag={props.tag}
-          size={props.size}
           digest={props.digest}
         />
       </Tab>
@@ -66,7 +65,6 @@ type TagTabsProps = {
   tag: Tag;
   org: string;
   repo: string;
-  size: number;
   digest: string;
   err: string;
 };


### PR DESCRIPTION
Makes the following changes:
- Size for child manifests are now computed correctly, by adding up the sizes of each layer
- Requests to security endpoint now pass the child digest instead of the parent digest to get the correct information
- Images with size `0` are displayed as unsupported. (Matches behavior of the old UI)
- Manifests with no features are displayed as unsupported. (Matches behavior of old UI)
- Architecture selection now displays operating system + architecture in dropdown
- Architecture selection value is tracked using digest since that is the unique value for the selected manifest

How to test
- Pull and run code locally. 
- Skopeo copy the `aspnet` image:
`skopeo copy docker://mcr.microsoft.com/dotnet/aspnet docker://localhost:8080/user/aspnet --all --dest-creds='user:pass' --dest-tls-verify=false`
- Security values should match the old UI for the child manifests
- Size values should be slightly larger (~3MB)
   - The old UI computes size values as [mibibytes while the new UI measures size in megabytes](https://www.techtarget.com/searchstorage/definition/mebibyte-MiB#:~:text=A%20mebibyte%20is%20equal%20to,they%20are%20often%20used%20synonymously.)