### PR TITLE
Fix security report loading error

### DIFF
--- a/src/routes/RepositoryDetails/Tags/SecurityDetails.tsx
+++ b/src/routes/RepositoryDetails/Tags/SecurityDetails.tsx
@@ -35,10 +35,6 @@ export default function SecurityDetails(props: SecurityDetailsProps) {
   const setGlobalErr = useSetRecoilState(SecurityDetailsErrorState);
   const setGlobalData = useSetRecoilState(SecurityDetailsState);
 
-  // Reset SecurityDetailsState so that loading skeletons appear when viewing report
-  const emptySecurityDetails = useResetRecoilState(SecurityDetailsState);
-  const resetSecurityDetails = () => emptySecurityDetails();
-
   const severityOrder = [
     VulnerabilitySeverity.Critical,
     VulnerabilitySeverity.High,
@@ -65,7 +61,7 @@ export default function SecurityDetails(props: SecurityDetailsProps) {
             await getSecurityDetails(props.org, props.repo, props.digest);
           const vulns = new Map<VulnerabilitySeverity, number>();
           if (securityDetails.data) {
-            setGlobalData(securityDetails);
+            if (props.cacheResults) setGlobalData(securityDetails);
             setHasFeatures(securityDetails.data.Layer.Features.length > 0);
             for (const feature of securityDetails.data.Layer.Features) {
               if (feature.Vulnerabilities) {
@@ -90,7 +86,7 @@ export default function SecurityDetails(props: SecurityDetailsProps) {
             'Unable to get security details',
             error,
           );
-          setGlobalErr(message);
+          if (props.cacheResults) setGlobalErr(message);
           setErr(message);
           setLoading(false);
         }
@@ -122,7 +118,6 @@ export default function SecurityDetails(props: SecurityDetailsProps) {
     return (
       <Link
         to={getTagDetailPath(props.org, props.repo, props.tag, queryParams)}
-        onClick={resetSecurityDetails}
         className={'pf-u-display-inline-flex pf-u-align-items-center'}
         style={{textDecoration: 'none'}}
       >
@@ -143,7 +138,6 @@ export default function SecurityDetails(props: SecurityDetailsProps) {
     return (
       <Link
         to={getTagDetailPath(props.org, props.repo, props.tag, queryParams)}
-        onClick={resetSecurityDetails}
         className={'pf-u-display-inline-flex pf-u-align-items-center'}
         style={{textDecoration: 'none'}}
       >
@@ -185,7 +179,6 @@ export default function SecurityDetails(props: SecurityDetailsProps) {
   return (
     <Link
       to={getTagDetailPath(props.org, props.repo, props.tag, queryParams)}
-      onClick={resetSecurityDetails}
       style={{textDecoration: 'none'}}
     >
       {counts}
@@ -199,4 +192,5 @@ export interface SecurityDetailsProps {
   tag: string;
   digest: string;
   variant?: Variant | 'condensed' | 'full';
+  cacheResults?: boolean;
 }

--- a/src/routes/TagDetails/Details/Details.tsx
+++ b/src/routes/TagDetails/Details/Details.tsx
@@ -10,7 +10,6 @@ import {
   Skeleton,
   Page,
 } from '@patternfly/react-core';
-import prettyBytes from 'pretty-bytes';
 import CopyTags from './DetailsCopyTags';
 import {Tag} from 'src/resources/TagResource';
 import {formatDate} from 'src/libs/utils';
@@ -103,6 +102,7 @@ export default function Details(props: DetailsProps) {
                 repo={props.repo}
                 digest={props.digest}
                 tag={props.tag.name}
+                cacheResults={true}
               />
             </DescriptionListDescription>
           </DescriptionListGroup>

--- a/src/routes/TagDetails/TagDetails.tsx
+++ b/src/routes/TagDetails/TagDetails.tsx
@@ -1,11 +1,8 @@
 import {
-  Breadcrumb,
-  BreadcrumbItem,
   Page,
   PageSection,
   PageSectionVariants,
   Title,
-  PageBreadcrumb,
 } from '@patternfly/react-core';
 import {useSearchParams, useLocation} from 'react-router-dom';
 import {useState, useEffect} from 'react';
@@ -17,17 +14,23 @@ import {
   getManifestByDigest,
   Tag,
   ManifestByDigestResponse,
-  Manifest,
 } from 'src/resources/TagResource';
 import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
 import {QuayBreadcrumb} from 'src/components/breadcrumb/Breadcrumb';
 import ErrorBoundary from 'src/components/errors/ErrorBoundary';
 import RequestError from 'src/components/errors/RequestError';
+import {useResetRecoilState} from 'recoil';
+import {
+  SecurityDetailsErrorState,
+  SecurityDetailsState,
+} from 'src/atoms/SecurityDetailsState';
 
 export default function TagDetails() {
   const [searchParams] = useSearchParams();
   const [digest, setDigest] = useState<string>('');
   const [err, setErr] = useState<string>();
+  const resetSecurityDetails = useResetRecoilState(SecurityDetailsState);
+  const resetSecurityError = useResetRecoilState(SecurityDetailsErrorState);
   const [tagDetails, setTagDetails] = useState<Tag>({
     name: '',
     is_manifest_list: false,
@@ -51,6 +54,8 @@ export default function TagDetails() {
 
   useEffect(() => {
     (async () => {
+      resetSecurityDetails();
+      resetSecurityError();
       try {
         const resp: TagsResponse = await getTags(org, repo, 1, 100, tag);
 


### PR DESCRIPTION
Fixes behavior for:
- When clicking `Vulnerabilities` section in the Tag Details page the security data state would be cleared causing the security report to render the loading screen that would never disappear. 
- When tag list was being loaded the recoil state for security data would be written to with each response but the information would never be read from. 

This PR causes the security state to be reset when the Tag Details page loads. 