### PR TITLE
Resetting select orgs

### DIFF
--- a/src/components/toolbar/Kebab.tsx
+++ b/src/components/toolbar/Kebab.tsx
@@ -10,7 +10,7 @@ export function Kebab(props: KebabProps) {
           onToggle={() => props.setKebabOpen(!props.isKebabOpen)}
           id="toggle-id-6"
         >
-          More Actions
+          Actions
         </DropdownToggle>
       }
       isOpen={props.isKebabOpen}

--- a/src/routes/OrganizationsList/OrganizationsList.tsx
+++ b/src/routes/OrganizationsList/OrganizationsList.tsx
@@ -255,6 +255,7 @@ export default function OrganizationsList() {
       try {
         setLoading(true);
         resetSearch();
+        setSelectedOrganization([]);
         const config = await fetchQuayConfig();
         const user: IUserResource = await fetchUser();
         setQuayConfig(config);


### PR DESCRIPTION
Resets selected orgs when navigating away from page. Renaming `More Actions` to `Actions`.