### PR TITLE
Adding permissions management to repository settings

### DIFF
--- a/cypress/e2e/org-list.cy.ts
+++ b/cypress/e2e/org-list.cy.ts
@@ -1,3 +1,5 @@
+/// <reference types="cypress" />
+
 describe('Org List Page', () => {
   beforeEach(() => {
     cy.exec('npm run quay:seed');
@@ -99,7 +101,7 @@ describe('Org List Page', () => {
   it('Pagination', () => {
     cy.visit('/organization');
 
-    cy.contains('1 - 10 of 25').should('exist');
+    cy.contains('1 - 10 of 26').should('exist');
     cy.get('td[data-label="Name"]').should('have.length', 10);
 
     // cycle through the pages
@@ -114,12 +116,12 @@ describe('Org List Page', () => {
     // Go to last page
     cy.get('button[aria-label="Go to last page"]').first().click();
     cy.contains('user1').should('exist');
-    cy.get('td[data-label="Name"]').should('have.length', 5);
+    cy.get('td[data-label="Name"]').should('have.length', 6);
 
     // Change per page
-    cy.get('button:contains("21 - 25 of 25")').first().click();
+    cy.get('button:contains("21 - 26 of 26")').first().click();
     cy.contains('20 per page').click();
     cy.get('td[data-label="Name"]').should('have.length', 20);
-    cy.contains('1 - 20 of 25').should('exist');
+    cy.contains('1 - 20 of 26').should('exist');
   });
 });

--- a/cypress/e2e/repositories-list.cy.ts
+++ b/cypress/e2e/repositories-list.cy.ts
@@ -18,7 +18,7 @@ describe('Repositories List Page', () => {
     cy.contains('Repositories').should('exist');
     cy.get('[data-testid="repository-list-table"]')
       .children()
-      .should('have.length', 3);
+      .should('have.length', 4);
     cy.get('[data-testid="repository-list-table"]').within(() => {
       cy.contains('user1/hello-world').should('exist');
       cy.contains('user1/nested/repo').should('exist');
@@ -144,12 +144,12 @@ describe('Repositories List Page', () => {
   it('makes multiple repositories public', () => {
     cy.visit('/repository');
     cy.get('button[id="toolbar-dropdown-checkbox"]').click();
-    cy.contains('Select page (3)').click();
+    cy.contains('Select page (4)').click();
     cy.contains('Actions').click();
     cy.contains('Make Public').click();
     cy.contains('Make repositories public');
     cy.contains(
-      'Update 3 repositories visibility to be public so they are visible to all user, and may be pulled by all users.',
+      'Update 4 repositories visibility to be public so they are visible to all user, and may be pulled by all users.',
     );
     cy.contains('Make public').click();
     cy.contains('private').should('not.exist');
@@ -158,12 +158,12 @@ describe('Repositories List Page', () => {
   it('makes multiple repositories private', () => {
     cy.visit('/repository');
     cy.get('button[id="toolbar-dropdown-checkbox"]').click();
-    cy.contains('Select page (3)').click();
+    cy.contains('Select page (4)').click();
     cy.contains('Actions').click();
     cy.contains('Make Private').click();
     cy.contains('Make repositories private');
     cy.contains(
-      'Update 3 repositories visibility to be private so they are only visible to certain users, and only may be pulled by certain users.',
+      'Update 4 repositories visibility to be private so they are only visible to certain users, and only may be pulled by certain users.',
     );
     cy.contains('Make private').click();
     cy.contains('public').should('not.exist');
@@ -208,15 +208,20 @@ describe('Repositories List Page', () => {
     }
     cy.intercept(
       'GET',
+      '/api/v1/repository?last_modified=true&namespace=*&public=true',
+      {repositories: []},
+    ).as('getRepositories');
+    cy.intercept(
+      'GET',
       '/api/v1/repository?last_modified=true&namespace=user1&public=true',
       {repositories: repos},
     ).as('getRepositories');
     cy.visit('/repository');
-    cy.contains('1 - 10 of 51').should('exist');
+    cy.contains('1 - 10 of 50').should('exist');
     cy.get('td[data-label="Name"]').should('have.length', 10);
 
     // Change per page
-    cy.get('button:contains("1 - 10 of 51")').first().click();
+    cy.get('button:contains("1 - 10 of 50")').first().click();
     cy.contains('20 per page').click();
     cy.get('td[data-label="Name"]').should('have.length', 20);
 
@@ -224,7 +229,7 @@ describe('Repositories List Page', () => {
     cy.get('button[aria-label="Go to next page"]').first().click();
     cy.get('td[data-label="Name"]').should('have.length', 20);
     cy.get('button[aria-label="Go to next page"]').first().click();
-    cy.get('td[data-label="Name"]').should('have.length', 11);
+    cy.get('td[data-label="Name"]').should('have.length', 10);
 
     // Go to first page
     cy.get('button[aria-label="Go to first page"]').first().click();
@@ -235,9 +240,9 @@ describe('Repositories List Page', () => {
     cy.contains('repo49').should('exist');
 
     // Switch per page while while being on a different page
-    cy.get('button:contains("41 - 51 of 51")').first().click();
+    cy.get('button:contains("41 - 50 of 50")').first().click();
     cy.contains('10 per page').click();
-    cy.contains('1 - 10 of 51').should('exist');
+    cy.contains('1 - 10 of 50').should('exist');
     cy.get('td[data-label="Name"]').should('have.length', 10);
   });
 });

--- a/cypress/e2e/repository-details.cy.ts
+++ b/cypress/e2e/repository-details.cy.ts
@@ -186,8 +186,8 @@ describe('Repository Details Page', () => {
 
   it('clicking platform name goes to tag details page', () => {
     cy.visit('/repository/user1/hello-world');
-    const firstRow = cy.get('tbody').first();
-    firstRow.within(() => {
+    const manifestListRow = cy.get('tbody:contains("manifestlist")').first();
+    manifestListRow.within(() => {
       cy.get('button').first().click();
       cy.get('a').contains('linux on amd64').click();
     });
@@ -246,7 +246,7 @@ describe('Repository Details Page', () => {
 
   it('search by name', () => {
     cy.visit('/repository/user1/hello-world');
-    cy.get('input[name="search input"]').type('test');
+    cy.get('#tagslist-search-input').type('test');
     cy.contains('latest').should('exist');
     cy.contains('manifestlist').should('not.exist');
   });
@@ -255,7 +255,7 @@ describe('Repository Details Page', () => {
     cy.visit('/repository/user1/hello-world');
     cy.get('#toolbar-dropdown-filter').click();
     cy.get('a').contains('Manifest').click();
-    cy.get('input[name="search input"]').type('f54a58bc1aac');
+    cy.get('#tagslist-search-input').type('f54a58bc1aac');
     cy.contains('latest').should('exist');
     cy.contains('manifestlist').should('not.exist');
   });

--- a/cypress/e2e/repository-permissions.cy.ts
+++ b/cypress/e2e/repository-permissions.cy.ts
@@ -1,0 +1,167 @@
+/// <reference types="cypress" />
+
+describe('Repository Details Page', () => {
+  beforeEach(() => {
+    cy.exec('npm run quay:seed');
+    cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
+      .then((response) => response.body.csrf_token)
+      .then((token) => {
+        cy.loginByCSRF(token);
+      });
+    cy.visit('/repositories/testorg/testrepo?tab=settings');
+  });
+
+  it('Renders permissions', () => {
+    const user1Row = cy.get('tr:contains("user1")');
+    user1Row.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'user1');
+      cy.get(`[data-label="type"]`).should('have.text', 'user');
+      cy.get(`[data-label="role"]`).should('have.text', 'admin');
+    });
+    const robotRow = cy.get('tr:contains("testorg+testrobot")');
+    robotRow.within(() => {
+      cy.get(`[data-label="membername"]`).should(
+        'have.text',
+        'testorg+testrobot',
+      );
+      cy.get(`[data-label="type"]`).should('have.text', 'robot');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+    const teamRow = cy.get('tr:contains("testteam")');
+    teamRow.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'testteam');
+      cy.get(`[data-label="type"]`).should('have.text', 'team');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+  });
+
+  it('Changes user/robot/team permissions inline', () => {
+    const user1Row = cy.get('tr:contains("user1")');
+    user1Row.within(() => {
+      cy.contains('admin').click();
+      cy.contains('Read').click();
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+    const robotRow = cy.get('tr:contains("testorg+testrobot")');
+    robotRow.within(() => {
+      cy.contains('read').click();
+      cy.contains('Write').click();
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+    const teamRow = cy.get('tr:contains("testteam")');
+    teamRow.within(() => {
+      cy.contains('read').click();
+      cy.contains('Write').click();
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+  });
+
+  it('Deletes user/robot/team permission inline', () => {
+    const user1Row = cy.get('tr:contains("user1")');
+    user1Row.within(() => {
+      cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
+      cy.contains('Delete Permission').click();
+      cy.contains('user1').should('not.exist');
+    });
+    const robotRow = cy.get('tr:contains("testorg+testrobot")');
+    robotRow.within(() => {
+      cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
+      cy.contains('Delete Permission').click();
+      cy.contains('testorg+testrobot').should('not.exist');
+    });
+    const teamRow = cy.get('tr:contains("testteam")');
+    teamRow.within(() => {
+      cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
+      cy.contains('Delete Permission').click();
+      cy.contains('testteam').should('not.exist');
+    });
+  });
+
+  it('Bulk deletes permissions', () => {
+    cy.contains('1 - 3 of 3').should('exist');
+    cy.get('#permissions-select-all').click();
+    cy.contains('Actions').click();
+    cy.contains('Delete').click();
+    cy.get('table').within(() => {
+      cy.contains('user1').should('not.exist');
+      cy.contains('testorg+testrobot').should('not.exist');
+      cy.contains('testteam').should('not.exist');
+    });
+  });
+
+  it('Bulk changes permissions', () => {
+    cy.contains('1 - 3 of 3').should('exist');
+    cy.get('#permissions-select-all').click();
+    cy.contains('Actions').click();
+    cy.contains('Change Permissions').click();
+    cy.get('#change-permissions-menu').within(() => {
+      cy.contains('Write').click();
+    });
+    const user1Row = cy.get('tr:contains("user1")');
+    user1Row.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'user1');
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+    const robotRow = cy.get('tr:contains("testorg+testrobot")');
+    robotRow.within(() => {
+      cy.get(`[data-label="membername"]`).should(
+        'have.text',
+        'testorg+testrobot',
+      );
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+    const teamRow = cy.get('tr:contains("testteam")');
+    teamRow.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'testteam');
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+  });
+
+  it('Adds user/robot/team permission', () => {
+    cy.contains('Add Permissions').click();
+    cy.get('#add-permission-form').within(() => {
+      cy.get('input').type('user');
+      cy.contains('user2').click();
+      cy.contains('admin').click();
+      cy.contains('Read').click();
+      cy.contains('Submit').click();
+    });
+    const user2Row = cy.get('tr:contains("user2")');
+    user2Row.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'user2');
+      cy.get(`[data-label="type"]`).should('have.text', 'user');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+    cy.contains('Add Permissions').click();
+    cy.get('#add-permission-form').within(() => {
+      cy.get('input').type('test');
+      cy.contains('testorg+testrobot2').click();
+      cy.contains('admin').click();
+      cy.contains('Read').click();
+      cy.contains('Submit').click();
+    });
+    const testrobot3Row = cy.get('tr:contains("testorg+testrobot2")');
+    testrobot3Row.within(() => {
+      cy.get(`[data-label="membername"]`).should(
+        'have.text',
+        'testorg+testrobot2',
+      );
+      cy.get(`[data-label="type"]`).should('have.text', 'robot');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+    cy.contains('Add Permissions').click();
+    cy.get('#add-permission-form').within(() => {
+      cy.get('input').type('test');
+      cy.contains('testteam2').click();
+      cy.contains('admin').click();
+      cy.contains('Read').click();
+      cy.contains('Submit').click();
+    });
+    const testteam2Row = cy.get('tr:contains("testteam2")');
+    testteam2Row.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'testteam2');
+      cy.get(`[data-label="type"]`).should('have.text', 'team');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+  });
+});

--- a/cypress/e2e/repository-permissions.cy.ts
+++ b/cypress/e2e/repository-permissions.cy.ts
@@ -8,7 +8,7 @@ describe('Repository Details Page', () => {
       .then((token) => {
         cy.loginByCSRF(token);
       });
-    cy.visit('/repositories/testorg/testrepo?tab=settings');
+    cy.visit('/repository/testorg/testrepo?tab=settings');
   });
 
   it('Renders permissions', () => {

--- a/cypress/test/quay-db-data.txt
+++ b/cypress/test/quay-db-data.txt
@@ -5436,6 +5436,8 @@ COPY public.externalnotificationmethod (id, name) FROM stdin;
 --
 
 COPY public.federatedlogin (id, user_id, service_id, service_ident, metadata_json) FROM stdin;
+1	30	2	robot:30	{}
+2	31	2	robot:31	{}
 \.
 
 
@@ -5596,6 +5598,16 @@ COPY public.logentry3 (id, kind_id, account_id, performer_id, repository_id, dat
 7	41	1	1	1	2022-11-15 13:35:43.687829	172.18.0.1	{"repo": "hello-world", "namespace": "user1", "user-agent": "docker/20.10.14 go/go1.16.15 git-commit/87a90dc kernel/5.10.104-linuxkit os/linux arch/amd64 UpstreamClient(Docker-Client/20.10.14 \\\\(darwin\\\\))", "tag": "latest", "username": "user1", "resolved_ip": {"provider": "internet", "service": null, "sync_token": "1645662201", "country_iso_code": null, "aws_region": null}}
 8	14	2	1	3	2022-11-21 18:50:13.652958	172.18.0.1	{"repo": "alpine", "namespace": "quay"}
 9	14	4	1	4	2022-11-21 18:51:52.359274	172.18.0.1	{"repo": "clair-jwt", "namespace": "projectquay"}
+10	32	28	1	\N	2022-11-29 13:46:42.873471	172.20.0.1	{"team": "testteam"}
+11	31	28	1	\N	2022-11-29 13:47:57.422707	172.20.0.1	{"member": "user2", "team": "testteam"}
+12	14	28	1	5	2022-11-29 13:48:12.920299	172.20.0.1	{"repo": "testrepo", "namespace": "testorg"}
+13	10	28	1	5	2022-11-29 13:48:23.378722	172.20.0.1	{"team": "testteam", "repo": "testrepo", "role": "read"}
+14	10	28	1	5	2022-11-29 13:48:31.251386	172.20.0.1	{"username": "user2", "repo": "testrepo", "namespace": "testorg", "role": "read"}
+15	15	28	1	\N	2022-11-29 13:48:39.02569	172.20.0.1	{"robot": "testrobot", "description": "", "unstructured_metadata": null}
+16	10	28	1	5	2022-11-29 13:48:40.92258	172.20.0.1	{"username": "testorg+testrobot", "repo": "testrepo", "namespace": "testorg", "role": "read"}
+17	22	28	1	5	2022-11-30 21:23:26.32246	172.20.0.1	{"username": "user2", "repo": "testrepo", "namespace": "testorg"}
+18	15	28	1	\N	2022-11-30 21:23:53.670728	172.20.0.1	{"robot": "testrobot2", "description": "", "unstructured_metadata": null}
+19	32	28	1	\N	2022-11-30 21:24:13.085006	172.20.0.1	{"team": "testteam2"}
 \.
 
 
@@ -5930,8 +5942,8 @@ COPY public.quayservice (id, name) FROM stdin;
 --
 
 COPY public.queueitem (id, queue_name, body, available_after, available, processing_expires, retries_remaining, state_id) FROM stdin;
-1	namespacegc/2/	{"marker_id": 1, "original_username": "quay"}	2022-11-21 19:08:59.907435	t	2022-11-21 22:03:59.822106	5	d16ca6ff-78c0-41f7-a0cd-3cbc34c4ce86
-2	namespacegc/3/	{"marker_id": 2, "original_username": "clair"}	2022-11-21 19:09:05.093576	t	2022-11-21 22:04:04.940845	5	14e73adf-53a7-4fc3-8be8-1458b2edbd6e
+1	namespacegc/2/	{"marker_id": 1, "original_username": "quay"}	2022-11-30 21:26:51.497982	t	2022-12-01 00:21:51.470842	5	a7c201f0-a472-48a7-8032-65e9ba2c766f
+2	namespacegc/3/	{"marker_id": 2, "original_username": "clair"}	2022-11-30 21:26:56.605709	t	2022-12-01 00:21:56.51308	5	c54c092e-4c5b-4c14-a687-6fa70a2b79c5
 \.
 
 
@@ -5978,6 +5990,7 @@ COPY public.repository (id, namespace_user_id, name, visibility_id, description,
 2	1	nested/repo	2		637a151b-62db-4c26-a160-0ba01d1c96d4	1	f	0
 3	2	alpine	1		9d24b211-b0af-47e2-9a88-543483b68461	1	f	0
 4	4	clair-jwt	1		cc957b5d-c4f8-4359-9bc9-f6e667a216da	1	f	0
+5	28	testrepo	2		8f1a8b8a-a83c-404b-bdd0-c087d3226560	1	f	0
 \.
 
 
@@ -5990,6 +6003,7 @@ COPY public.repositoryactioncount (id, repository_id, count, date) FROM stdin;
 2	2	0	2022-11-13
 3	3	0	2022-11-20
 4	4	0	2022-11-20
+5	5	0	2022-11-28
 \.
 
 
@@ -6044,6 +6058,9 @@ COPY public.repositorypermission (id, team_id, user_id, repository_id, role_id) 
 2	\N	1	2	1
 3	\N	1	3	1
 4	\N	1	4	1
+5	\N	1	5	1
+6	28	\N	5	3
+8	\N	30	5	3
 \.
 
 
@@ -6056,6 +6073,7 @@ COPY public.repositorysearchscore (id, repository_id, score, last_updated) FROM 
 2	2	0	\N
 3	3	0	\N
 4	4	0	\N
+5	5	0	\N
 \.
 
 
@@ -6068,6 +6086,7 @@ COPY public.repositorysize (id, repository_id, size_bytes) FROM stdin;
 3	3	0
 2	2	0
 4	4	0
+5	5	0
 \.
 
 
@@ -6084,6 +6103,8 @@ COPY public.repositorytag (id, name, image_id, repository_id, lifetime_start_ts,
 --
 
 COPY public.robotaccountmetadata (id, robot_account_id, description, unstructured_json) FROM stdin;
+1	30		{}
+2	31		{}
 \.
 
 
@@ -6092,6 +6113,8 @@ COPY public.robotaccountmetadata (id, robot_account_id, description, unstructure
 --
 
 COPY public.robotaccounttoken (id, robot_account_id, token, fully_migrated) FROM stdin;
+1	30	v0$$sQInfFzCekHc9zEgzkQCI/7GPvqp0vVQ2M8fEw9X9lOQ0nZBudr/KTv2P1XpStSeXIo3ODMkG4kNxXaDDnElT6VW9LdwnzgLAfCUnguW5IW+fof/icsRCRzN99kG	t
+2	31	v0$$x8LiHeFTsuFkPd0yL8lrR7hXJtPG2XnCks7fSqD4Ql+NtwIKatgcx2pNLB98VX4lLSAMb99PmSUqYA+CGCM1UG/EG/VV36KY6PgVS8tk5XVEtemHOsy7bIy4j7xs	t
 \.
 
 
@@ -6235,6 +6258,9 @@ COPY public.team (id, name, organization_id, role_id, description) FROM stdin;
 24	owners	25	1	
 25	owners	26	1	
 26	owners	27	1	
+27	owners	28	1	
+28	testteam	28	3	
+29	testteam2	28	3	
 \.
 
 
@@ -6267,6 +6293,8 @@ COPY public.teammember (id, user_id, team_id) FROM stdin;
 24	1	24
 25	1	25
 26	1	26
+27	1	27
+28	29	28
 \.
 
 
@@ -6336,7 +6364,6 @@ COPY public.uploadedblob (id, repository_id, blob_id, uploaded_at, expires_at) F
 --
 
 COPY public."user" (id, uuid, username, password_hash, email, verified, stripe_id, organization, robot, invoice_email, invalid_login_attempts, last_invalid_login, removed_tag_expiration_s, enabled, invoice_email_address, company, family_name, given_name, location, maximum_queued_builds_count, creation_date, last_accessed) FROM stdin;
-1	5a177ae4-b114-4557-ab6a-c6947f618b55	user1	$2b$12$c4u19A/x6a.6Ihm2pAin7.nXUCIqI0vtf7miS7tZ.oXhHtsKVS.Bq	user1@redhat.com	t	\N	f	f	f	0	2022-10-31 18:50:36.685961	1209600	t	\N	\N	\N	\N	\N	\N	2022-10-31 18:50:36.685976	\N
 2	478983be-9239-479c-9ca6-86d85eb5bcae	89aced10-1ceb-4fa0-a21d-eea28b821060	\N	eba37a66-0b41-4352-86c5-438a1875d5e5	f	\N	t	f	f	0	2022-11-21 18:49:53.667717	1209600	f	\N	\N	\N	\N	\N	\N	2022-11-21 18:49:53.667738	\N
 3	b72c9d43-eb51-4dee-996a-ef6e78c92db7	aee7990b-975d-42f2-b9be-b357a5aa3f3f	\N	33b3d332-b72f-4754-b9d3-816aca5261b3	f	\N	t	f	f	0	2022-11-21 18:50:35.411588	1209600	f	\N	\N	\N	\N	\N	\N	2022-11-21 18:50:35.411606	\N
 4	ec029590-9f7f-4886-9bec-d11925542ed6	projectquay	\N	4e003156-02a9-4d51-8c22-a110e7c86aa9	f	\N	t	f	f	0	2022-11-21 18:51:23.259811	1209600	t	\N	\N	\N	\N	\N	\N	2022-11-21 18:51:23.259828	\N
@@ -6363,6 +6390,11 @@ COPY public."user" (id, uuid, username, password_hash, email, verified, stripe_i
 25	ce824049-c743-463a-a15b-5dacdbdd9174	minio	\N	9b2204ea-0cbf-46f5-b9e9-43fd0c28117e	f	\N	t	f	f	0	2022-11-21 18:56:21.537146	1209600	t	\N	\N	\N	\N	\N	\N	2022-11-21 18:56:21.537163	\N
 26	df00c09a-f39b-4afe-b676-91d5bee4e507	centos	\N	ae63b4ec-f66a-48b2-a5fb-5f46d8a3e953	f	\N	t	f	f	0	2022-11-21 18:56:36.90184	1209600	t	\N	\N	\N	\N	\N	\N	2022-11-21 18:56:36.901869	\N
 27	06580557-80cb-4b69-83cd-09b9c538330b	ceph	\N	3260450e-c0b6-4cf6-90ca-ce31c882fa80	f	\N	t	f	f	0	2022-11-21 18:56:42.081825	1209600	t	\N	\N	\N	\N	\N	\N	2022-11-21 18:56:42.081839	\N
+28	45c1c5df-3c10-4aa3-acba-5a15ea53e420	testorg	\N	c50be933-debc-4ed0-b1a0-df461c2f7456	f	\N	t	f	f	0	2022-11-29 13:46:30.797525	1209600	t	\N	\N	\N	\N	\N	\N	2022-11-29 13:46:30.797539	\N
+1	918b26a3-cbf2-434c-a18f-dad69167193e	user1	$2b$12$c4u19A/x6a.6Ihm2pAin7.nXUCIqI0vtf7miS7tZ.oXhHtsKVS.Bq	user1@redhat.com	t	\N	f	f	f	0	2022-10-31 18:50:36.685961	1209600	t	\N	\N	\N	\N	\N	\N	2022-10-31 18:50:36.685976	\N
+29	ee9bb1db-b80e-4707-b8b5-44249236d1da	user2	$2b$12$XA6iXw/.Ug.F8s7bWVz3VuWcOz0SVKsmnvkgl.l6ZnmWWllTgzLT6	user2@redhat.com	t	\N	f	f	f	0	2022-11-29 13:47:39.871581	1209600	t	\N	\N	\N	\N	\N	\N	2022-11-29 13:47:39.87159	\N
+30	824e31bd-e531-4a2a-838d-cfdc7442978f	testorg+testrobot	\N	b4a78057-79f2-440a-b089-e2779be746b9	f	\N	f	t	f	0	2022-11-29 13:48:38.924504	1209600	t	\N	\N	\N	\N	\N	\N	2022-11-29 13:48:38.924541	\N
+31	87860588-5674-4bc4-a297-abda8f99e877	testorg+testrobot2	\N	c117d71c-c3cb-4513-ab37-32f0dcb16007	f	\N	f	t	f	0	2022-11-30 21:23:53.656399	1209600	t	\N	\N	\N	\N	\N	\N	2022-11-30 21:23:53.656402	\N
 \.
 
 
@@ -6562,7 +6594,7 @@ SELECT pg_catalog.setval('public.externalnotificationmethod_id_seq', 6, true);
 -- Name: federatedlogin_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.federatedlogin_id_seq', 1, false);
+SELECT pg_catalog.setval('public.federatedlogin_id_seq', 2, true);
 
 
 --
@@ -6639,7 +6671,7 @@ SELECT pg_catalog.setval('public.logentry2_id_seq', 1, false);
 -- Name: logentry3_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.logentry3_id_seq', 9, true);
+SELECT pg_catalog.setval('public.logentry3_id_seq', 19, true);
 
 
 --
@@ -6835,14 +6867,14 @@ SELECT pg_catalog.setval('public.repomirrorrule_id_seq', 1, false);
 -- Name: repository_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.repository_id_seq', 4, true);
+SELECT pg_catalog.setval('public.repository_id_seq', 5, true);
 
 
 --
 -- Name: repositoryactioncount_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.repositoryactioncount_id_seq', 4, true);
+SELECT pg_catalog.setval('public.repositoryactioncount_id_seq', 5, true);
 
 
 --
@@ -6884,21 +6916,21 @@ SELECT pg_catalog.setval('public.repositorynotification_id_seq', 1, false);
 -- Name: repositorypermission_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.repositorypermission_id_seq', 4, true);
+SELECT pg_catalog.setval('public.repositorypermission_id_seq', 8, true);
 
 
 --
 -- Name: repositorysearchscore_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.repositorysearchscore_id_seq', 4, true);
+SELECT pg_catalog.setval('public.repositorysearchscore_id_seq', 5, true);
 
 
 --
 -- Name: repositorysize_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.repositorysize_id_seq', 4, true);
+SELECT pg_catalog.setval('public.repositorysize_id_seq', 5, true);
 
 
 --
@@ -6912,14 +6944,14 @@ SELECT pg_catalog.setval('public.repositorytag_id_seq', 1, false);
 -- Name: robotaccountmetadata_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.robotaccountmetadata_id_seq', 1, false);
+SELECT pg_catalog.setval('public.robotaccountmetadata_id_seq', 2, true);
 
 
 --
 -- Name: robotaccounttoken_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.robotaccounttoken_id_seq', 1, false);
+SELECT pg_catalog.setval('public.robotaccounttoken_id_seq', 2, true);
 
 
 --
@@ -7003,14 +7035,14 @@ SELECT pg_catalog.setval('public.tagtorepositorytag_id_seq', 1, false);
 -- Name: team_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.team_id_seq', 26, true);
+SELECT pg_catalog.setval('public.team_id_seq', 29, true);
 
 
 --
 -- Name: teammember_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.teammember_id_seq', 26, true);
+SELECT pg_catalog.setval('public.teammember_id_seq', 28, true);
 
 
 --
@@ -7052,7 +7084,7 @@ SELECT pg_catalog.setval('public.uploadedblob_id_seq', 18, true);
 -- Name: user_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.user_id_seq', 27, true);
+SELECT pg_catalog.setval('public.user_id_seq', 31, true);
 
 
 --

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@patternfly/react-core": "^4.202.16",
         "@patternfly/react-icons": "^4.53.16",
         "@patternfly/react-table": "^4.71.16",
+        "@tanstack/react-query": "^4.13.5",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
@@ -4597,6 +4598,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.13.4.tgz",
+      "integrity": "sha512-DMIy6tgGehYoRUFyoR186+pQspOicyZNSGvBWxPc2CinHjWOQ7DPnGr9zmn/kE9xK4Zd3GXd25Nj3X20+TF6Lw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.13.5.tgz",
+      "integrity": "sha512-p2HcWGuqfvG7Pz04un4phWZeXzlITD7Ue0gMXjD56g8y3rP1r5qEYC/BckffrZLf4dZtQeVPCWOa8RYAqx036g==",
+      "dependencies": {
+        "@tanstack/query-core": "4.13.4",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/dom": {
@@ -27311,6 +27347,14 @@
         "react-router": ">=6.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -32437,6 +32481,20 @@
         "@svgr/plugin-jsx": "^5.5.0",
         "@svgr/plugin-svgo": "^5.5.0",
         "loader-utils": "^2.0.0"
+      }
+    },
+    "@tanstack/query-core": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.13.4.tgz",
+      "integrity": "sha512-DMIy6tgGehYoRUFyoR186+pQspOicyZNSGvBWxPc2CinHjWOQ7DPnGr9zmn/kE9xK4Zd3GXd25Nj3X20+TF6Lw=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.13.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.13.5.tgz",
+      "integrity": "sha512-p2HcWGuqfvG7Pz04un4phWZeXzlITD7Ue0gMXjD56g8y3rP1r5qEYC/BckffrZLf4dZtQeVPCWOa8RYAqx036g==",
+      "requires": {
+        "@tanstack/query-core": "4.13.4",
+        "use-sync-external-store": "^1.2.0"
       }
     },
     "@testing-library/dom": {
@@ -49705,6 +49763,12 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/use-react-router-breadcrumbs/-/use-react-router-breadcrumbs-3.2.1.tgz",
       "integrity": "sha512-GpDhGo/A0I1ckGLER1/YZX/tgX+KOAyCGG2HgFIc0SVzQ30hTilufNdNRN3Gt+WXJW0zgn48CxxKvKSe+xA3TA==",
+      "requires": {}
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "requires": {}
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@patternfly/react-core": "^4.202.16",
     "@patternfly/react-icons": "^4.53.16",
     "@patternfly/react-table": "^4.71.16",
+    "@tanstack/react-query": "^4.13.5",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, {Suspense, useEffect} from 'react';
 import {BrowserRouter, Route, Routes} from 'react-router-dom';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 
 import 'src/App.css';
 
@@ -7,15 +8,25 @@ import {LoadingPage} from 'src/components/LoadingPage';
 import {StandaloneMain} from 'src/routes/StandaloneMain';
 import {Signin} from 'src/routes/Signin/Signin';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
 export default function App() {
   return (
     <div className="App">
       <BrowserRouter>
         <Suspense fallback={<LoadingPage />}>
-          <Routes>
-            <Route path="/*" element={<StandaloneMain />} />
-            <Route path="/signin" element={<Signin />} />
-          </Routes>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route path="/*" element={<StandaloneMain />} />
+              <Route path="/signin" element={<Signin />} />
+            </Routes>
+          </QueryClientProvider>
         </Suspense>
       </BrowserRouter>
     </div>

--- a/src/components/Table/Menu.tsx
+++ b/src/components/Table/Menu.tsx
@@ -1,0 +1,83 @@
+import {
+  Menu as PFMenu,
+  MenuList,
+  MenuToggle,
+  Popper,
+} from '@patternfly/react-core';
+import React, {useEffect, useRef} from 'react';
+
+export default function Menu({isOpen, setIsOpen, ...props}: MenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const onToggleClick = (ev: React.MouseEvent) => {
+    ev.stopPropagation(); // Stop handleClickOutside from handling
+    setTimeout(() => {
+      if (menuRef.current) {
+        const firstElement = menuRef.current.querySelector(
+          'li > button:not(:disabled), li > a:not(:disabled)',
+        );
+        firstElement && (firstElement as HTMLElement).focus();
+      }
+    }, 0);
+    setIsOpen(!isOpen);
+  };
+
+  const handleMenuKeys = (event: KeyboardEvent) => {
+    if (!isOpen) {
+      return;
+    }
+    if (
+      menuRef.current?.contains(event.target as Node) ||
+      toggleRef.current?.contains(event.target as Node)
+    ) {
+      if (event.key === 'Escape' || event.key === 'Tab') {
+        setIsOpen(!isOpen);
+        toggleRef.current?.focus();
+      }
+    }
+  };
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (isOpen && !menuRef.current?.contains(event.target as Node)) {
+      setIsOpen(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleMenuKeys);
+    window.addEventListener('click', handleClickOutside);
+    return () => {
+      window.removeEventListener('keydown', handleMenuKeys);
+      window.removeEventListener('click', handleClickOutside);
+    };
+  }, [isOpen, menuRef]);
+
+  return (
+    <div ref={containerRef}>
+      <Popper
+        trigger={
+          <MenuToggle onClick={onToggleClick} isExpanded={isOpen}>
+            {props.toggle}
+          </MenuToggle>
+        }
+        popper={
+          <PFMenu ref={menuRef} containsFlyout>
+            <MenuList>{props.items}</MenuList>
+          </PFMenu>
+        }
+        appendTo={containerRef.current || undefined}
+        isVisible={isOpen}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
+  );
+}
+
+interface MenuProps {
+  items: React.ReactNode[];
+  toggle: string;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+}

--- a/src/components/empty/Conditional.tsx
+++ b/src/components/empty/Conditional.tsx
@@ -1,0 +1,9 @@
+// Renders conditional components in a more markup friendly way
+export default function Conditional(props: ConditionalProps) {
+  return props.if ? <>{props.children}</> : null;
+}
+
+interface ConditionalProps {
+  children: React.ReactNode;
+  if: boolean;
+}

--- a/src/components/toolbar/DropdownCheckbox.tsx
+++ b/src/components/toolbar/DropdownCheckbox.tsx
@@ -65,7 +65,7 @@ export function DropdownCheckbox(props: DropdownCheckboxProps) {
           <DropdownToggle
             splitButtonItems={[
               <DropdownToggleCheckbox
-                id="split-button-text-checkbox"
+                id={props.id ? props.id : 'split-button-text-checkbox'}
                 key="split-checkbox"
                 aria-label="Select all"
                 isChecked={props.selectedItems.length > 0 ? true : false}
@@ -95,4 +95,5 @@ type DropdownCheckboxProps = {
   allItemsList: any[];
   itemsPerPageList: any[];
   onItemSelect: (Item, rowIndex, isSelecting) => void;
+  id?: string;
 };

--- a/src/components/toolbar/SearchInput.tsx
+++ b/src/components/toolbar/SearchInput.tsx
@@ -12,7 +12,7 @@ export function SearchInput(props: SearchInput) {
       <TextInput
         isRequired
         type="search"
-        id="toolbar-text-input"
+        id={props.id ? props.id : 'toolbar-text-input'}
         name="search input"
         placeholder={`Search by ${props.searchState.field}...`}
         value={props.searchState.query}
@@ -25,4 +25,5 @@ export function SearchInput(props: SearchInput) {
 interface SearchInput {
   searchState: SearchState;
   onChange: SetterOrUpdater<SearchState>;
+  id?: string;
 }

--- a/src/hooks/UseEntities.ts
+++ b/src/hooks/UseEntities.ts
@@ -1,0 +1,22 @@
+import {useQuery} from '@tanstack/react-query';
+import {useState} from 'react';
+import {fetchEntities} from 'src/resources/UserResource';
+
+export function useEntities(org: string) {
+  const [searchTerm, setSearchTerm] = useState<string>();
+  const {data: entities, isError} = useQuery(
+    ['fetchentities', org, searchTerm],
+    () => fetchEntities(org, searchTerm),
+    {
+      placeholderData: [],
+      enabled: searchTerm != null && searchTerm != '',
+    },
+  );
+
+  return {
+    entities: !isError ? entities : [],
+    isError: isError,
+    searchTerm: searchTerm,
+    setSearchTerm: setSearchTerm,
+  };
+}

--- a/src/hooks/UseEntities.ts
+++ b/src/hooks/UseEntities.ts
@@ -1,17 +1,31 @@
 import {useQuery} from '@tanstack/react-query';
-import {useState} from 'react';
-import {fetchEntities} from 'src/resources/UserResource';
+import {useEffect, useState} from 'react';
+import {Entity, fetchEntities} from 'src/resources/UserResource';
 
 export function useEntities(org: string) {
   const [searchTerm, setSearchTerm] = useState<string>();
-  const {data: entities, isError} = useQuery(
-    ['fetchentities', org, searchTerm],
-    () => fetchEntities(org, searchTerm),
-    {
-      placeholderData: [],
-      enabled: searchTerm != null && searchTerm != '',
-    },
-  );
+  const [isError, setIsError] = useState<boolean>();
+  const [entities, setEntities] = useState<Entity[]>([]);
+
+  const search = async () => {
+    try {
+      const entityResults = await fetchEntities(org, searchTerm);
+      setEntities(entityResults);
+    } catch (err) {
+      setIsError(true);
+    }
+  };
+
+  // If next character typed is under a second, don't fire the
+  // request
+  useEffect(() => {
+    const delay = setTimeout(() => {
+      if (searchTerm != null && searchTerm != '') {
+        search();
+      }
+    }, 1000);
+    return () => clearTimeout(delay);
+  }, [searchTerm]);
 
   return {
     entities: !isError ? entities : [],

--- a/src/hooks/UseRepositoryPermissions.ts
+++ b/src/hooks/UseRepositoryPermissions.ts
@@ -26,6 +26,7 @@ export function useRepositoryPermissions(org: string, repo: string) {
     data: userRoles,
     isError: errorLoadingUserRoles,
     isLoading: loadingUserRoles,
+    isPlaceholderData: isUserPlaceholderData,
   } = useQuery(
     ['userrepopermissions', org, repo],
     () => fetchUserRepoPermissions(org, repo),
@@ -38,6 +39,7 @@ export function useRepositoryPermissions(org: string, repo: string) {
     data: teamRoles,
     isError: errorLoadingTeamRoles,
     isLoading: loadingTeamRoles,
+    isPlaceholderData: isTeamPlaceholderData,
   } = useQuery(
     ['teamrepopermissions', org, repo],
     () => fetchTeamRepoPermissions(org, repo),
@@ -80,7 +82,11 @@ export function useRepositoryPermissions(org: string, repo: string) {
   );
 
   return {
-    loading: loadingUserRoles || loadingTeamRoles,
+    loading:
+      loadingUserRoles ||
+      loadingTeamRoles ||
+      isUserPlaceholderData ||
+      isTeamPlaceholderData,
     error: errorLoadingUserRoles || errorLoadingTeamRoles,
     members: members,
     paginatedMembers: paginatedMembers,

--- a/src/hooks/UseRepositoryPermissions.ts
+++ b/src/hooks/UseRepositoryPermissions.ts
@@ -1,0 +1,96 @@
+import {useQuery} from '@tanstack/react-query';
+import {useState} from 'react';
+import {SearchState} from 'src/components/toolbar/SearchTypes';
+import {
+  fetchTeamRepoPermissions,
+  fetchUserRepoPermissions,
+  RepoMember,
+} from 'src/resources/RepositoryResource';
+import ColumnNames from 'src/routes/RepositoryDetails/Settings/ColumnNames';
+
+enum MemberType {
+  user = 'user',
+  robot = 'robot',
+  team = 'team',
+}
+
+export function useRepositoryPermissions(org: string, repo: string) {
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(10);
+  const [search, setSearch] = useState<SearchState>({
+    query: '',
+    field: ColumnNames.account,
+  });
+
+  const {
+    data: userRoles,
+    isError: errorLoadingUserRoles,
+    isLoading: loadingUserRoles,
+  } = useQuery(
+    ['userrepopermissions', org, repo],
+    () => fetchUserRepoPermissions(org, repo),
+    {
+      placeholderData: {},
+    },
+  );
+
+  const {
+    data: teamRoles,
+    isError: errorLoadingTeamRoles,
+    isLoading: loadingTeamRoles,
+  } = useQuery(
+    ['teamrepopermissions', org, repo],
+    () => fetchTeamRepoPermissions(org, repo),
+    {
+      placeholderData: {},
+    },
+  );
+
+  const members: RepoMember[] = [];
+  for (const [name, roleData] of Object.entries(userRoles)) {
+    const type: MemberType = roleData.is_robot
+      ? MemberType.robot
+      : MemberType.user;
+    members.push({
+      org: org,
+      repo: repo,
+      name: name,
+      type: type,
+      role: roleData.role,
+    });
+  }
+  for (const [name, roleData] of Object.entries(teamRoles)) {
+    members.push({
+      org: org,
+      repo: repo,
+      name: name,
+      type: MemberType.team,
+      role: roleData.role,
+    });
+  }
+
+  const filteredMembers =
+    search.query !== ''
+      ? members?.filter((role) => role.name.includes(search.query))
+      : members;
+
+  const paginatedMembers = filteredMembers?.slice(
+    page * perPage - perPage,
+    page * perPage - perPage + perPage,
+  );
+
+  return {
+    loading: loadingUserRoles || loadingTeamRoles,
+    error: errorLoadingUserRoles || errorLoadingTeamRoles,
+    members: members,
+    paginatedMembers: paginatedMembers,
+
+    page: page,
+    setPage: setPage,
+    perPage: perPage,
+    setPerPage: setPerPage,
+
+    search: search,
+    setSearch: setSearch,
+  };
+}

--- a/src/hooks/UseUpdateRepositoryPermissions.ts
+++ b/src/hooks/UseUpdateRepositoryPermissions.ts
@@ -1,0 +1,64 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {
+  bulkDeleteRepoPermissions,
+  bulkSetRepoPermissions,
+  RepoMember,
+  RepoRole,
+} from 'src/resources/RepositoryResource';
+
+export function useUpdateRepositoryPermissions(org: string, repo: string) {
+  const queryClient = useQueryClient();
+  const {
+    mutate: setPermissions,
+    isError: errorSetPermissions,
+    isSuccess: successSetPermissions,
+    reset: resetSetRepoPermissions,
+  } = useMutation(
+    async ({
+      members,
+      newRole,
+    }: {
+      members: RepoMember[] | RepoMember;
+      newRole: RepoRole;
+    }) => {
+      members = Array.isArray(members) ? members : [members];
+      return bulkSetRepoPermissions(members, newRole);
+    },
+    {
+      onSuccess: (_, variables) => {
+        queryClient.invalidateQueries(['teamrepopermissions']);
+        queryClient.invalidateQueries(['userrepopermissions']);
+      },
+    },
+  );
+
+  const {
+    mutate: deletePermissions,
+    isError: errorDeletePermissions,
+    isSuccess: successDeletePermissions,
+    reset: resetDeleteRepoPermissions,
+  } = useMutation(
+    async (members: RepoMember[] | RepoMember) => {
+      members = Array.isArray(members) ? members : [members];
+      return bulkDeleteRepoPermissions(members);
+    },
+    {
+      onSuccess: (_, variables) => {
+        queryClient.invalidateQueries(['teamrepopermissions']);
+        queryClient.invalidateQueries(['userrepopermissions']);
+      },
+    },
+  );
+
+  return {
+    setPermissions: setPermissions,
+    errorSetPermissions: errorSetPermissions,
+    successSetPermissions: successSetPermissions,
+    resetSetRepoPermissions: resetSetRepoPermissions,
+
+    deletePermissions: deletePermissions,
+    errorDeletePermissions: errorDeletePermissions,
+    successDeletePermissions: successDeletePermissions,
+    resetDeleteRepoPermissions: resetDeleteRepoPermissions,
+  };
+}

--- a/src/resources/UserResource.ts
+++ b/src/resources/UserResource.ts
@@ -1,3 +1,4 @@
+import {AvatarProps} from '@patternfly/react-core';
 import {AxiosResponse} from 'axios';
 import axios from 'src/libs/axios';
 import {assertHttpCode} from './ErrorHandling';
@@ -52,4 +53,29 @@ export async function fetchUsersAsSuperUser() {
   const response: AxiosResponse<AllUsers> = await axios.get(superUserOrgsUrl);
   assertHttpCode(response.status, 200);
   return response.data?.users;
+}
+
+export interface Entity {
+  avatar: IAvatar;
+  is_org_member: boolean;
+  name: string;
+  kind: string;
+  is_robot?: boolean;
+}
+
+interface EntitiesResponse {
+  results: Entity[];
+}
+
+export async function fetchEntities(org: string, search: string) {
+  // Handles the case of robot accounts, API doesn't recognize anything before the + sign
+  if (search.indexOf('+') > -1) {
+    const splitSearchTerm = search.split('+');
+    search = splitSearchTerm.length > 1 ? splitSearchTerm[1] : '';
+  }
+  const response: AxiosResponse<EntitiesResponse> = await axios.get(
+    `/api/v1/entities/${search}?namespace=${org}&includeTeams=true`,
+  );
+  assertHttpCode(response.status, 200);
+  return response.data?.results;
 }

--- a/src/routes/RepositoryDetails/Settings/ColumnNames.ts
+++ b/src/routes/RepositoryDetails/Settings/ColumnNames.ts
@@ -1,0 +1,7 @@
+const ColumnNames = {
+  account: 'Account',
+  type: 'Type',
+  permissions: 'Permissions',
+};
+
+export default ColumnNames;

--- a/src/routes/RepositoryDetails/Settings/Permissions.tsx
+++ b/src/routes/RepositoryDetails/Settings/Permissions.tsx
@@ -1,0 +1,115 @@
+import {Spinner} from '@patternfly/react-core';
+import {
+  TableComposable,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
+import {useState} from 'react';
+import {useRepositoryPermissions} from 'src/hooks/UseRepositoryPermissions';
+import PermissionsToolbar from './PermissionsToolbar';
+import ColumnNames from './ColumnNames';
+import PermissionsDropdown from './PermissionsDropdown';
+import {RepoMember} from 'src/resources/RepositoryResource';
+import PermissionsKebab from './PermissionsKebab';
+import {DrawerContentType} from '../Types';
+
+export default function Permissions(props: PermissionsProps) {
+  const {
+    members,
+    paginatedMembers,
+    loading,
+    error,
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    search,
+    setSearch,
+  } = useRepositoryPermissions(props.org, props.repo);
+  const [selectedMembers, setSelectedMembers] = useState<RepoMember[]>([]);
+
+  const onSelectMember = (
+    member: RepoMember,
+    rowIndex: number,
+    isSelecting: boolean,
+  ) => {
+    setSelectedMembers((prevSelected) => {
+      const others = prevSelected.filter((r) => r.name !== member.name);
+      return isSelecting ? [...others, member] : others;
+    });
+  };
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (error) {
+    return <>Unable to load permissions list</>;
+  }
+
+  return (
+    <>
+      <PermissionsToolbar
+        org={props.org}
+        repo={props.repo}
+        allItems={members}
+        paginatedItems={paginatedMembers}
+        selectedItems={selectedMembers}
+        page={page}
+        setPage={setPage}
+        perPage={perPage}
+        setPerPage={setPerPage}
+        searchOptions={[ColumnNames.account]}
+        search={search}
+        setSearch={setSearch}
+        onItemSelect={onSelectMember}
+        deselectAll={() => setSelectedMembers([])}
+        setDrawerContent={props.setDrawerContent}
+      />
+      <TableComposable aria-label="Repository permissions table">
+        <Thead>
+          <Tr>
+            <Th />
+            <Th>{ColumnNames.account}</Th>
+            <Th>{ColumnNames.type}</Th>
+            <Th>{ColumnNames.permissions}</Th>
+            <Th />
+          </Tr>
+        </Thead>
+        <Tbody>
+          {paginatedMembers?.map((member, rowIndex) => (
+            <Tr key={member.name}>
+              <Td
+                select={{
+                  rowIndex,
+                  onSelect: (e, isSelecting) =>
+                    onSelectMember(member, rowIndex, isSelecting),
+                  isSelected: selectedMembers.some(
+                    (r) => r.name === member.name,
+                  ),
+                }}
+              />
+              <Td data-label="membername">{member.name}</Td>
+              <Td data-label="type">{member.type}</Td>
+              <Td data-label="role">
+                <PermissionsDropdown member={member} />
+              </Td>
+              <Td data-label="kebab">
+                <PermissionsKebab member={member} />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
+    </>
+  );
+}
+
+interface PermissionsProps {
+  org: string;
+  repo: string;
+  setDrawerContent: (content: DrawerContentType) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/PermissionsActionsChangePermissions.tsx
+++ b/src/routes/RepositoryDetails/Settings/PermissionsActionsChangePermissions.tsx
@@ -1,0 +1,84 @@
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertGroup,
+  DropdownItem,
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuList,
+} from '@patternfly/react-core';
+import {useEffect} from 'react';
+import Conditional from 'src/components/empty/Conditional';
+import {useUpdateRepositoryPermissions} from 'src/hooks/UseUpdateRepositoryPermissions';
+import {RepoMember} from 'src/resources/RepositoryResource';
+import {roles} from './Types';
+
+export default function ChangePermissions(props: ChangePermissionsProps) {
+  const {
+    setPermissions,
+    errorSetPermissions: error,
+    successSetPermissions: success,
+    resetSetRepoPermissions,
+  } = useUpdateRepositoryPermissions(props.org, props.repo);
+
+  useEffect(() => {
+    if (success) {
+      props.deselectAll();
+      props.setIsMenuOpen(false);
+    }
+  }, [success]);
+
+  return (
+    <>
+      <Conditional if={error}>
+        <AlertGroup isToast isLiveRegion>
+          <Alert
+            variant={'danger'}
+            title={`Unable to set repository permissions`}
+            actionClose={
+              <AlertActionCloseButton onClose={resetSetRepoPermissions} />
+            }
+          />
+        </AlertGroup>
+      </Conditional>
+      <MenuItem
+        id="change-permissions-menu"
+        flyoutMenu={
+          <Menu key={1}>
+            <MenuContent>
+              <MenuList>
+                {roles.map((role) => (
+                  <MenuItem
+                    key={role.name}
+                    description={role.description}
+                    onClick={() =>
+                      setPermissions({
+                        members: props.selectedItems,
+                        newRole: role.role,
+                      })
+                    }
+                    style={{width: 'max-content'}}
+                  >
+                    {role.name}
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </MenuContent>
+          </Menu>
+        }
+        itemId="next-menu-root"
+      >
+        Change Permissions
+      </MenuItem>
+    </>
+  );
+}
+
+export interface ChangePermissionsProps {
+  org: string;
+  repo: string;
+  selectedItems: RepoMember[];
+  deselectAll: () => void;
+  setIsMenuOpen: (isOpen: boolean) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/PermissionsActionsDelete.tsx
+++ b/src/routes/RepositoryDetails/Settings/PermissionsActionsDelete.tsx
@@ -1,0 +1,57 @@
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertGroup,
+  MenuItem,
+} from '@patternfly/react-core';
+import {useEffect} from 'react';
+import Conditional from 'src/components/empty/Conditional';
+import {useUpdateRepositoryPermissions} from 'src/hooks/UseUpdateRepositoryPermissions';
+import {RepoMember} from 'src/resources/RepositoryResource';
+
+export default function Delete(props: DeleteProps) {
+  const {
+    deletePermissions,
+    errorDeletePermissions: error,
+    successDeletePermissions: success,
+    resetDeleteRepoPermissions,
+  } = useUpdateRepositoryPermissions(props.org, props.repo);
+
+  useEffect(() => {
+    if (success) {
+      props.deselectAll();
+      props.setIsMenuOpen(false);
+    }
+  }, [success]);
+
+  return (
+    <>
+      <Conditional if={error}>
+        <AlertGroup isToast isLiveRegion>
+          <Alert
+            variant="danger"
+            title="Unable to bulk delete repository permissions"
+            actionClose={
+              <AlertActionCloseButton onClose={resetDeleteRepoPermissions} />
+            }
+          />
+        </AlertGroup>
+      </Conditional>
+      <MenuItem
+        onClick={() => {
+          deletePermissions(props.selectedItems);
+        }}
+      >
+        Delete
+      </MenuItem>
+    </>
+  );
+}
+
+export interface DeleteProps {
+  org: string;
+  repo: string;
+  selectedItems: RepoMember[];
+  deselectAll: () => void;
+  setIsMenuOpen: (isOpen: boolean) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/PermissionsAddPermission.tsx
+++ b/src/routes/RepositoryDetails/Settings/PermissionsAddPermission.tsx
@@ -1,0 +1,167 @@
+import {
+  ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  AlertGroup,
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  Form,
+  FormGroup,
+  Select,
+  SelectOption,
+  SelectVariant,
+  Title,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import Conditional from 'src/components/empty/Conditional';
+import {useEntities} from 'src/hooks/UseEntities';
+import {useUpdateRepositoryPermissions} from 'src/hooks/UseUpdateRepositoryPermissions';
+import {
+  RepoMember,
+  MemberType,
+  RepoRole,
+} from 'src/resources/RepositoryResource';
+import {Entity} from 'src/resources/UserResource';
+import {roles} from './Types';
+
+export default function AddPermissions(props: AddPermissionsProps) {
+  const [isUserOpen, setIsUserOpen] = useState<boolean>(false);
+  const [isPermissionOpen, setIsPermissionOpen] = useState<boolean>(false);
+  const [role, setRole] = useState<RepoRole>(RepoRole.admin);
+  const {
+    entities,
+    isError: errorFetchingEntities,
+    searchTerm,
+    setSearchTerm,
+  } = useEntities(props.org);
+  const {
+    setPermissions,
+    errorSetPermissions: errorSettingPermissions,
+    successSetPermissions: success,
+    resetSetRepoPermissions,
+  } = useUpdateRepositoryPermissions(props.org, props.repo);
+
+  const filteredEntities = entities.filter((e) => e.name === searchTerm);
+  const validInput = filteredEntities.length > 0;
+  const selectedEntity =
+    filteredEntities.length > 0 ? filteredEntities[0] : null;
+
+  const getMemberType = (entity: Entity) => {
+    if (entity.kind == MemberType.team) {
+      return MemberType.team;
+    } else if (entity.kind == MemberType.user && entity.is_robot) {
+      return MemberType.robot;
+    } else if (entity.kind == MemberType.user) {
+      return MemberType.user;
+    }
+  };
+
+  const createPermission = () => {
+    const member: RepoMember = {
+      org: props.org,
+      repo: props.repo,
+      name: selectedEntity.name,
+      type: getMemberType(selectedEntity),
+      role: null,
+    };
+    setPermissions({members: member, newRole: role});
+  };
+
+  useEffect(() => {
+    if (success) {
+      resetSetRepoPermissions();
+      props.closeDrawer();
+    }
+  }, [success]);
+
+  return (
+    <>
+      <Title headingLevel="h3">Add Permission</Title>
+      <Conditional if={errorFetchingEntities}>
+        <Alert isInline variant="danger" title="Unable to lookup users" />
+      </Conditional>
+      <Conditional if={errorSettingPermissions}>
+        <Alert
+          isInline
+          actionClose={
+            <AlertActionCloseButton onClose={resetSetRepoPermissions} />
+          }
+          variant="danger"
+          title="Unable to set permissions"
+        />
+      </Conditional>
+      <Form id="add-permission-form">
+        <FormGroup fieldId="user" label="Select a user" required>
+          <Select
+            isOpen={isUserOpen}
+            selections={searchTerm}
+            onSelect={(e, value) => {
+              setSearchTerm(value as string);
+              setIsUserOpen(!isUserOpen);
+            }}
+            onToggle={() => {
+              setIsUserOpen(!isUserOpen);
+            }}
+            variant={SelectVariant.typeahead}
+            onTypeaheadInputChanged={(value) => {
+              setSearchTerm(value);
+            }}
+            shouldResetOnSelect={true}
+            onClear={() => {
+              setSearchTerm('');
+            }}
+          >
+            {entities.map((e) => (
+              <SelectOption
+                key={e.name}
+                value={e.name}
+                description={getMemberType(e)}
+              />
+            ))}
+          </Select>
+        </FormGroup>
+        <FormGroup fieldId="permission" label="Select a permission" required>
+          <Dropdown
+            onSelect={() => setIsPermissionOpen(false)}
+            toggle={
+              <DropdownToggle
+                onToggle={(isOpen) => setIsPermissionOpen(isOpen)}
+              >
+                {role}
+              </DropdownToggle>
+            }
+            isOpen={isPermissionOpen}
+            dropdownItems={roles.map((role) => (
+              <DropdownItem
+                key={role.name}
+                description={role.description}
+                onClick={() => setRole(role.role)}
+              >
+                {role.name}
+              </DropdownItem>
+            ))}
+          />
+        </FormGroup>
+        <ActionGroup>
+          <Button
+            isDisabled={!validInput}
+            onClick={() => {
+              createPermission();
+            }}
+            variant="primary"
+          >
+            Submit
+          </Button>
+        </ActionGroup>
+      </Form>
+    </>
+  );
+}
+
+interface AddPermissionsProps {
+  org: string;
+  repo: string;
+  closeDrawer: () => void;
+}

--- a/src/routes/RepositoryDetails/Settings/PermissionsDropdown.tsx
+++ b/src/routes/RepositoryDetails/Settings/PermissionsDropdown.tsx
@@ -1,0 +1,64 @@
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertGroup,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+} from '@patternfly/react-core';
+import {useState} from 'react';
+import Conditional from 'src/components/empty/Conditional';
+import {useUpdateRepositoryPermissions} from 'src/hooks/UseUpdateRepositoryPermissions';
+import {RepoMember} from 'src/resources/RepositoryResource';
+import {roles} from './Types';
+
+export default function PermissionsDropdown({
+  member,
+}: PermissionsDropdownProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const {
+    setPermissions,
+    errorSetPermissions: error,
+    resetSetRepoPermissions,
+  } = useUpdateRepositoryPermissions(member.org, member.repo);
+
+  return (
+    <>
+      <Conditional if={error}>
+        <AlertGroup isToast isLiveRegion>
+          <Alert
+            variant={'danger'}
+            title={`Unable to set permissions for ${member.name}`}
+            actionClose={
+              <AlertActionCloseButton onClose={resetSetRepoPermissions} />
+            }
+          />
+        </AlertGroup>
+      </Conditional>
+      <Dropdown
+        onSelect={() => setIsOpen(false)}
+        toggle={
+          <DropdownToggle onToggle={(isOpen) => setIsOpen(isOpen)}>
+            {member.role}
+          </DropdownToggle>
+        }
+        isOpen={isOpen}
+        dropdownItems={roles.map((role) => (
+          <DropdownItem
+            key={role.name}
+            description={role.description}
+            onClick={() =>
+              setPermissions({members: member, newRole: role.role})
+            }
+          >
+            {role.name}
+          </DropdownItem>
+        ))}
+      />
+    </>
+  );
+}
+
+export interface PermissionsDropdownProps {
+  member: RepoMember;
+}

--- a/src/routes/RepositoryDetails/Settings/PermissionsKebab.tsx
+++ b/src/routes/RepositoryDetails/Settings/PermissionsKebab.tsx
@@ -1,0 +1,65 @@
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertGroup,
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+} from '@patternfly/react-core';
+import {useState} from 'react';
+import Conditional from 'src/components/empty/Conditional';
+import {useUpdateRepositoryPermissions} from 'src/hooks/UseUpdateRepositoryPermissions';
+import {RepoMember} from 'src/resources/RepositoryResource';
+
+export default function PermissionsKebab({member}: PermissionsKebabProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const {
+    deletePermissions,
+    errorDeletePermissions: error,
+    resetDeleteRepoPermissions,
+  } = useUpdateRepositoryPermissions(member.org, member.repo);
+
+  const onSelect = () => {
+    setIsOpen(false);
+    const element = document.getElementById(`${member.name}-toggle-kebab`);
+    element.focus();
+  };
+
+  return (
+    <>
+      <Conditional if={error}>
+        <AlertGroup isToast isLiveRegion>
+          <Alert
+            variant="danger"
+            title={`Unable to set permissions for ${member.name}`}
+            actionClose={
+              <AlertActionCloseButton onClose={resetDeleteRepoPermissions} />
+            }
+          />
+        </AlertGroup>
+      </Conditional>
+      <Dropdown
+        onSelect={onSelect}
+        toggle={
+          <KebabToggle
+            id={`${member.name}-toggle-kebab`}
+            onToggle={() => {
+              setIsOpen(!isOpen);
+            }}
+          />
+        }
+        isOpen={isOpen}
+        dropdownItems={[
+          <DropdownItem key="delete" onClick={() => deletePermissions(member)}>
+            Delete Permission
+          </DropdownItem>,
+        ]}
+        isPlain
+      />
+    </>
+  );
+}
+
+interface PermissionsKebabProps {
+  member: RepoMember;
+}

--- a/src/routes/RepositoryDetails/Settings/PermissionsToolbar.tsx
+++ b/src/routes/RepositoryDetails/Settings/PermissionsToolbar.tsx
@@ -1,0 +1,115 @@
+import {
+  Button,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import {useState} from 'react';
+import Conditional from 'src/components/empty/Conditional';
+import Menu from 'src/components/Table/Menu';
+import {DropdownCheckbox} from 'src/components/toolbar/DropdownCheckbox';
+import {SearchDropdown} from 'src/components/toolbar/SearchDropdown';
+import {SearchInput} from 'src/components/toolbar/SearchInput';
+import {SearchState} from 'src/components/toolbar/SearchTypes';
+import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
+import {RepoMember} from 'src/resources/RepositoryResource';
+import {DrawerContentType} from '../Types';
+import ChangePermissions from './PermissionsActionsChangePermissions';
+import Delete from './PermissionsActionsDelete';
+
+export default function PermissionsToolbar(props: PermissionsToolbarProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+  return (
+    <Toolbar>
+      <ToolbarContent>
+        <DropdownCheckbox
+          id="permissions-select-all"
+          selectedItems={props.selectedItems}
+          deSelectAll={props.deselectAll}
+          allItemsList={props.allItems}
+          itemsPerPageList={props.paginatedItems}
+          onItemSelect={props.onItemSelect}
+        />
+        <SearchDropdown
+          items={props.searchOptions}
+          searchState={props.search}
+          setSearchState={props.setSearch}
+        />
+        <SearchInput
+          id="permissions-search-input"
+          searchState={props.search}
+          onChange={props.setSearch}
+        />
+        <ToolbarItem>
+          <Button
+            onClick={() =>
+              props.setDrawerContent(DrawerContentType.AddPermission)
+            }
+          >
+            Add Permissions
+          </Button>
+        </ToolbarItem>
+        <ToolbarItem>
+          <Conditional if={props.selectedItems?.length > 0}>
+            <Menu
+              toggle="Actions"
+              isOpen={isMenuOpen}
+              setIsOpen={setIsMenuOpen}
+              items={[
+                <Delete
+                  key="delete-action"
+                  deselectAll={props.deselectAll}
+                  org={props.org}
+                  repo={props.repo}
+                  selectedItems={props.selectedItems}
+                  setIsMenuOpen={setIsMenuOpen}
+                />,
+                <ChangePermissions
+                  key="change-permissions-action"
+                  deselectAll={props.deselectAll}
+                  org={props.org}
+                  repo={props.repo}
+                  selectedItems={props.selectedItems}
+                  setIsMenuOpen={setIsMenuOpen}
+                />,
+              ]}
+            />
+          </Conditional>
+        </ToolbarItem>
+        <ToolbarPagination
+          itemsList={props.allItems}
+          perPage={props.perPage}
+          page={props.page}
+          setPage={props.setPage}
+          setPerPage={props.setPerPage}
+        />
+      </ToolbarContent>
+    </Toolbar>
+  );
+}
+
+interface PermissionsToolbarProps {
+  org: string;
+  repo: string;
+
+  allItems: RepoMember[];
+  paginatedItems: RepoMember[];
+  selectedItems: RepoMember[];
+
+  page: number;
+  setPage: (page: number) => void;
+  perPage: number;
+  setPerPage: (perPage: number) => void;
+
+  searchOptions: string[];
+  search: SearchState;
+  setSearch: (search: SearchState) => void;
+
+  onItemSelect: (
+    item: RepoMember,
+    rowIndex: number,
+    isSelecting: boolean,
+  ) => void;
+  deselectAll: () => void;
+  setDrawerContent: (content: DrawerContentType) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/Settings.tsx
+++ b/src/routes/RepositoryDetails/Settings/Settings.tsx
@@ -1,0 +1,56 @@
+import {Flex, FlexItem, Tab, Tabs, TabTitleText} from '@patternfly/react-core';
+import {useState} from 'react';
+import {DrawerContentType} from 'src/routes/RepositoryDetails/Types';
+import Permissions from './Permissions';
+
+export default function Settings(props: SettingsProps) {
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+
+  const tabs = [
+    {
+      name: 'User and robot permissions',
+      id: 'userandrobotpermissions',
+      content: (
+        <Permissions
+          org={props.org}
+          repo={props.repo}
+          setDrawerContent={props.setDrawerContent}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <Flex flexWrap={{default: 'nowrap'}}>
+      <FlexItem>
+        <Tabs
+          activeKey={activeTabIndex}
+          onSelect={(e, index: number) => setActiveTabIndex(index)}
+          isVertical
+          aria-label="Repository Settings Tabs"
+          role="region"
+        >
+          {tabs.map((tab, tabIndex) => (
+            <Tab
+              key={tab.id}
+              eventKey={tabIndex}
+              title={<TabTitleText>{tab.name}</TabTitleText>}
+            />
+          ))}
+        </Tabs>
+      </FlexItem>
+      <FlexItem
+        alignSelf={{default: 'alignSelfCenter'}}
+        style={{padding: '20px', width: '100%'}}
+      >
+        {tabs.at(activeTabIndex).content}
+      </FlexItem>
+    </Flex>
+  );
+}
+
+interface SettingsProps {
+  org: string;
+  repo: string;
+  setDrawerContent: (content: DrawerContentType) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/Types.ts
+++ b/src/routes/RepositoryDetails/Settings/Types.ts
@@ -1,0 +1,25 @@
+import {RepoRole} from 'src/resources/RepositoryResource';
+
+export interface RoleOption {
+  name: string;
+  description: string;
+  role: RepoRole;
+}
+
+export const roles: RoleOption[] = [
+  {
+    name: 'Read',
+    description: 'Can view and pull from the repository',
+    role: RepoRole.read,
+  },
+  {
+    name: 'Write',
+    description: 'Can view, pull, and push to the repository',
+    role: RepoRole.write,
+  },
+  {
+    name: 'Admin',
+    description: 'Full admin access to the organization',
+    role: RepoRole.admin,
+  },
+];

--- a/src/routes/RepositoryDetails/Tags/Tags.tsx
+++ b/src/routes/RepositoryDetails/Tags/Tags.tsx
@@ -26,14 +26,10 @@ import RequestError from 'src/components/errors/RequestError';
 import Empty from 'src/components/empty/Empty';
 import {CubesIcon} from '@patternfly/react-icons';
 import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
-import {
-  fetchRepositoryDetails,
-  RepositoryDetails,
-} from 'src/resources/RepositoryResource';
+import {RepositoryDetails} from 'src/resources/RepositoryResource';
 
 export default function Tags(props: TagsProps) {
   const [tags, setTags] = useState<Tag[]>([]);
-  const [repoDetails, setRepoDetails] = useState<RepositoryDetails>();
   const [loading, setLoading] = useState<boolean>(true);
   const [err, setErr] = useState<string>();
   const resetSelectedTags = useResetRecoilState(selectedTagsState);
@@ -75,12 +71,6 @@ export default function Tags(props: TagsProps) {
     let page = 1;
     let hasAdditional = false;
     try {
-      const repoDetails = await fetchRepositoryDetails(
-        props.organization,
-        props.repository,
-      );
-      setRepoDetails(repoDetails);
-
       do {
         const resp: TagsResponse = await getTags(
           props.organization,
@@ -143,7 +133,7 @@ export default function Tags(props: TagsProps) {
             setPage={setPage}
             setPerPage={setPerPage}
             selectTag={selectTag}
-            repoDetails={repoDetails}
+            repoDetails={props.repoDetails}
           />
           <Table
             org={props.organization}
@@ -173,4 +163,5 @@ export default function Tags(props: TagsProps) {
 type TagsProps = {
   organization: string;
   repository: string;
+  repoDetails: RepositoryDetails;
 };

--- a/src/routes/RepositoryDetails/Tags/TagsToolbar.tsx
+++ b/src/routes/RepositoryDetails/Tags/TagsToolbar.tsx
@@ -53,8 +53,11 @@ export function TagsToolbar(props: ToolBarProps) {
           setSearchState={setSearch}
           items={[ColumnNames.name, ColumnNames.manifest]}
         />
-        <SearchInput searchState={search} onChange={setSearch} />
-
+        <SearchInput
+          id="tagslist-search-input"
+          searchState={search}
+          onChange={setSearch}
+        />
         <ToolbarItem>
           {selectedTags?.length !== 0 ? (
             <Kebab

--- a/src/routes/RepositoryDetails/Types.ts
+++ b/src/routes/RepositoryDetails/Types.ts
@@ -1,0 +1,4 @@
+export enum DrawerContentType {
+  None,
+  AddPermission,
+}


### PR DESCRIPTION
Adds the user/robot/team permissions management to repository settings. Gives the following functionality:
- Add user/robot/team permission
- Delete permission inline
- Change permission inline
- Bulk delete permissions
- Bulk change permissions

Changes can be tested with a quay instance and running `npm run quay:seed` and visiting `http://localhost:9000/repositories/testorg/testrepo?tab=settings`

These changes require the following [Quay PR](https://github.com/quay/quay/pull/1651) to merged in order to successfully run `PUT` requests.