### PR TITLE
Repository Notifications

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     },
     baseUrl: 'http://localhost:9000',
     video: false,
-    defaultCommandTimeout: 20000,
+    defaultCommandTimeout: 25000,
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/repository-notifications.cy.ts
+++ b/cypress/e2e/repository-notifications.cy.ts
@@ -23,7 +23,7 @@ describe('Repository Settings - Notifications', () => {
     const flowdockRow = cy.get('tr:contains("(Untitled)")');
     flowdockRow.within(() => {
       cy.get(`[data-label="title"]`).should('have.text', '(Untitled)');
-      cy.get(`[data-label="event"]`).should('have.text', ' Image build failed');
+      cy.get(`[data-label="event"]`).should('have.text', 'Image build failed');
       cy.get(`[data-label="notification"]`).should(
         'have.text',
         'Flowdock Team Notification',
@@ -36,7 +36,7 @@ describe('Repository Settings - Notifications', () => {
         'have.text',
         'hipchat-notification',
       );
-      cy.get(`[data-label="event"]`).should('have.text', ' Image build queued');
+      cy.get(`[data-label="event"]`).should('have.text', 'Image build queued');
       cy.get(`[data-label="notification"]`).should(
         'have.text',
         'HipChat Room Notification',
@@ -48,7 +48,7 @@ describe('Repository Settings - Notifications', () => {
       cy.get(`[data-label="title"]`).should('have.text', 'slack-notification');
       cy.get(`[data-label="event"]`).should(
         'have.text',
-        ' Package Vulnerability Found',
+        'Package Vulnerability Found',
       );
       cy.get(`[data-label="notification"]`).should(
         'have.text',
@@ -67,7 +67,7 @@ describe('Repository Settings - Notifications', () => {
       );
       cy.get(`[data-label="event"]`).should(
         'have.text',
-        ' Repository mirror started',
+        'Repository mirror started',
       );
       cy.get(`[data-label="notification"]`).should('have.text', 'Webhook POST');
       cy.get(`[data-label="status"]`).should(
@@ -80,7 +80,7 @@ describe('Repository Settings - Notifications', () => {
       cy.get(`[data-label="title"]`).should('have.text', 'email-notification');
       cy.get(`[data-label="event"]`).should(
         'have.text',
-        ' Repository mirror successful',
+        'Repository mirror successful',
       );
       cy.get(`[data-label="notification"]`).should(
         'contain.text',
@@ -161,7 +161,7 @@ describe('Repository Settings - Notifications', () => {
   //     const newnotificationRow = cy.get('tr:contains("newnotification")');
   //     newnotificationRow.within(()=>{
   //         cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
-  //         cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+  //         cy.get(`[data-label="event"]`).should('have.text', 'Push to Repository');
   //         cy.get(`[data-label="notification"]`).should('contain.text', 'Red Hat Quay Notification');
   //         cy.get(`[data-label="status"]`).should('have.text', 'Enabled');
   //     })
@@ -181,7 +181,7 @@ describe('Repository Settings - Notifications', () => {
     const newnotificationRow = cy.get('tr:contains("newnotification")');
     newnotificationRow.within(() => {
       cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
-      cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+      cy.get(`[data-label="event"]`).should('have.text', 'Push to Repository');
       cy.get(`[data-label="notification"]`).should(
         'contain.text',
         'Flowdock Team Notification',
@@ -205,7 +205,7 @@ describe('Repository Settings - Notifications', () => {
     const newnotificationRow = cy.get('tr:contains("newnotification")');
     newnotificationRow.within(() => {
       cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
-      cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+      cy.get(`[data-label="event"]`).should('have.text', 'Push to Repository');
       cy.get(`[data-label="notification"]`).should(
         'contain.text',
         'HipChat Room Notification',
@@ -230,7 +230,7 @@ describe('Repository Settings - Notifications', () => {
     const newnotificationRow = cy.get('tr:contains("newnotification")');
     newnotificationRow.within(() => {
       cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
-      cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+      cy.get(`[data-label="event"]`).should('have.text', 'Push to Repository');
       cy.get(`[data-label="notification"]`).should(
         'contain.text',
         'Slack Notification',
@@ -256,7 +256,7 @@ describe('Repository Settings - Notifications', () => {
     const newnotificationRow = cy.get('tr:contains("newnotification")');
     newnotificationRow.within(() => {
       cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
-      cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+      cy.get(`[data-label="event"]`).should('have.text', 'Push to Repository');
       cy.get(`[data-label="notification"]`).should(
         'contain.text',
         'Webhook POST',

--- a/cypress/e2e/repository-notifications.cy.ts
+++ b/cypress/e2e/repository-notifications.cy.ts
@@ -1,0 +1,338 @@
+/// <reference types="cypress" />
+
+describe('Repository Settings - Notifications', () => {
+  beforeEach(() => {
+    cy.exec('npm run quay:seed');
+    cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
+      .then((response) => response.body.csrf_token)
+      .then((token) => {
+        cy.loginByCSRF(token);
+      });
+    // Enable the repository settings feature
+    cy.intercept('GET', '/config', (req) =>
+      req.reply((res) => {
+        res.body.features['UI_V2_REPO_SETTINGS'] = true;
+        return res;
+      }),
+    ).as('getConfig');
+    cy.visit('/repository/testorg/testrepo?tab=settings');
+    cy.contains('Events and notifications').click();
+  });
+
+  it('Renders notifications', () => {
+    const flowdockRow = cy.get('tr:contains("(Untitled)")');
+    flowdockRow.within(() => {
+      cy.get(`[data-label="title"]`).should('have.text', '(Untitled)');
+      cy.get(`[data-label="event"]`).should('have.text', ' Image build failed');
+      cy.get(`[data-label="notification"]`).should(
+        'have.text',
+        'Flowdock Team Notification',
+      );
+      cy.get(`[data-label="status"]`).should('have.text', 'Enabled');
+    });
+    const hipchatRow = cy.get('tr:contains("hipchat-notification")');
+    hipchatRow.within(() => {
+      cy.get(`[data-label="title"]`).should(
+        'have.text',
+        'hipchat-notification',
+      );
+      cy.get(`[data-label="event"]`).should('have.text', ' Image build queued');
+      cy.get(`[data-label="notification"]`).should(
+        'have.text',
+        'HipChat Room Notification',
+      );
+      cy.get(`[data-label="status"]`).should('have.text', 'Enabled');
+    });
+    const slackRow = cy.get('tr:contains("slack-notification")');
+    slackRow.within(() => {
+      cy.get(`[data-label="title"]`).should('have.text', 'slack-notification');
+      cy.get(`[data-label="event"]`).should(
+        'have.text',
+        ' Package Vulnerability Found',
+      );
+      cy.get(`[data-label="notification"]`).should(
+        'have.text',
+        'Slack Notification',
+      );
+      cy.get(`[data-label="status"]`).should(
+        'have.text',
+        'Disabled due to 3 failed attempts in a row',
+      );
+    });
+    const webhookRow = cy.get('tr:contains("webhook-notification")');
+    webhookRow.within(() => {
+      cy.get(`[data-label="title"]`).should(
+        'have.text',
+        'webhook-notification',
+      );
+      cy.get(`[data-label="event"]`).should(
+        'have.text',
+        ' Repository mirror started',
+      );
+      cy.get(`[data-label="notification"]`).should('have.text', 'Webhook POST');
+      cy.get(`[data-label="status"]`).should(
+        'have.text',
+        'Disabled due to 3 failed attempts in a row',
+      );
+    });
+    const emailRow = cy.get('tr:contains("email-notification")');
+    emailRow.within(() => {
+      cy.get(`[data-label="title"]`).should('have.text', 'email-notification');
+      cy.get(`[data-label="event"]`).should(
+        'have.text',
+        ' Repository mirror successful',
+      );
+      cy.get(`[data-label="notification"]`).should(
+        'contain.text',
+        'Email Notification',
+      );
+      cy.get(`[data-label="notification"]`).should(
+        'contain.text',
+        'email: user1@redhat.com',
+      );
+      cy.get(`[data-label="status"]`).should(
+        'have.text',
+        'Disabled due to 3 failed attempts in a row',
+      );
+    });
+  });
+
+  it('Inline tests notification', () => {
+    const flowdockRow = cy.get('tr:contains("(Untitled)")');
+    flowdockRow.within(() => {
+      cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
+      cy.contains('Test Notification').click();
+    });
+    cy.contains('Test Notification Queued').should('exist');
+    cy.contains(
+      'A test version of this notification has been queued and should appear shortly',
+    ).should('exist');
+  });
+
+  it('Inline enables notification', () => {
+    const emailRow = cy.get('tr:contains("email-notification")');
+    emailRow.within(() => {
+      cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
+      cy.contains('Enable Notification').click();
+      cy.get(`[data-label="status"]`).should('have.text', 'Enabled');
+    });
+  });
+
+  it('Inline deletes notification', () => {
+    const emailRow = cy.get('tr:contains("email-notification")');
+    emailRow.within(() => {
+      cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
+      cy.contains('Delete Notification').click();
+      cy.contains('email-notification').should('not.exist');
+    });
+  });
+
+  it('Bulk enables notification', () => {
+    cy.get('#notifications-select-all').click();
+    cy.contains('Actions').click();
+    cy.contains('Enable').click();
+    cy.contains('Disabled due to 3 failed attempts in a row').should(
+      'not.exist',
+    );
+  });
+
+  it('Bulk deletes notification', () => {
+    cy.get('#notifications-select-all').click();
+    cy.contains('Actions').click();
+    cy.contains('Delete').click();
+    cy.contains('No notifications found');
+    cy.contains('No notifications have been setup for this repository');
+  });
+
+  // TODO: Need notifications in the header
+  // to be implemented first
+  // it('Creates quay notification',()=>{
+  //     cy.contains('Create Notification').click();
+  //     cy.get('#create-notification-form').within(()=>{
+  //         cy.contains('Select event').click();
+  //         cy.contains('Push to Repository').click();
+  //         cy.contains('Select method').click();
+  //         cy.contains('Red Hat Quay Notification').click();
+  //         cy.get('#entity-search-select-typeahead').type('user2');
+  //         cy.contains('user2').click();
+  //         cy.get('#notification-title').type('newnotification');
+  //         cy.contains('Submit').click();
+  //     })
+  //     const newnotificationRow = cy.get('tr:contains("newnotification")');
+  //     newnotificationRow.within(()=>{
+  //         cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
+  //         cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+  //         cy.get(`[data-label="notification"]`).should('contain.text', 'Red Hat Quay Notification');
+  //         cy.get(`[data-label="status"]`).should('have.text', 'Enabled');
+  //     })
+  // });
+
+  it('Creates Flowdock notification', () => {
+    cy.contains('Create Notification').click();
+    cy.get('#create-notification-form').within(() => {
+      cy.contains('Select event').click();
+      cy.contains('Push to Repository').click();
+      cy.contains('Select method').click();
+      cy.contains('Flowdock Team Notification').click();
+      cy.get('#flowdock-api-token-field').type('testtoken');
+      cy.get('#notification-title').type('newnotification');
+      cy.contains('Submit').click();
+    });
+    const newnotificationRow = cy.get('tr:contains("newnotification")');
+    newnotificationRow.within(() => {
+      cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
+      cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+      cy.get(`[data-label="notification"]`).should(
+        'contain.text',
+        'Flowdock Team Notification',
+      );
+      cy.get(`[data-label="status"]`).should('have.text', 'Enabled');
+    });
+  });
+
+  it('Creates Hipchat notification', () => {
+    cy.contains('Create Notification').click();
+    cy.get('#create-notification-form').within(() => {
+      cy.contains('Select event').click();
+      cy.contains('Push to Repository').click();
+      cy.contains('Select method').click();
+      cy.contains('HipChat Room Notification').click();
+      cy.get('#room-id-number-field').type('12345');
+      cy.get('#room-notification-token-field').type('testtoken');
+      cy.get('#notification-title').type('newnotification');
+      cy.contains('Submit').click();
+    });
+    const newnotificationRow = cy.get('tr:contains("newnotification")');
+    newnotificationRow.within(() => {
+      cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
+      cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+      cy.get(`[data-label="notification"]`).should(
+        'contain.text',
+        'HipChat Room Notification',
+      );
+      cy.get(`[data-label="status"]`).should('have.text', 'Enabled');
+    });
+  });
+
+  it('Creates Slack notification', () => {
+    cy.contains('Create Notification').click();
+    cy.get('#create-notification-form').within(() => {
+      cy.contains('Select event').click();
+      cy.contains('Push to Repository').click();
+      cy.contains('Select method').click();
+      cy.contains('Slack Notification').click();
+      cy.get('#slack-webhook-url-field').type(
+        'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX',
+      );
+      cy.get('#notification-title').type('newnotification');
+      cy.contains('Submit').click();
+    });
+    const newnotificationRow = cy.get('tr:contains("newnotification")');
+    newnotificationRow.within(() => {
+      cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
+      cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+      cy.get(`[data-label="notification"]`).should(
+        'contain.text',
+        'Slack Notification',
+      );
+      cy.get(`[data-label="status"]`).should('have.text', 'Enabled');
+    });
+  });
+
+  it('Creates Webhook notification', () => {
+    cy.contains('Create Notification').click();
+    cy.get('#create-notification-form').within(() => {
+      cy.contains('Select event').click();
+      cy.contains('Push to Repository').click();
+      cy.contains('Select method').click();
+      cy.contains('Webhook POST').click();
+      cy.get('#webhook-url-field').type('https://doesnotexist');
+      cy.get('#json-body-field').type('{"foo":"bar"}', {
+        parseSpecialCharSequences: false,
+      });
+      cy.get('#notification-title').type('newnotification');
+      cy.contains('Submit').click();
+    });
+    const newnotificationRow = cy.get('tr:contains("newnotification")');
+    newnotificationRow.within(() => {
+      cy.get(`[data-label="title"]`).should('have.text', 'newnotification');
+      cy.get(`[data-label="event"]`).should('have.text', ' Push to Repository');
+      cy.get(`[data-label="notification"]`).should(
+        'contain.text',
+        'Webhook POST',
+      );
+      cy.get(`[data-label="status"]`).should('have.text', 'Enabled');
+    });
+  });
+
+  // We're mocking this workflow because of the complexity in
+  // implementing the email auth flow in the CI
+  it('Creates email notification', () => {
+    const responses = [
+      {
+        email: 'user2@redhat.com',
+        repository: 'testrepo',
+        namespace: 'testorg',
+        confirmed: false,
+      },
+      {
+        email: 'user2@redhat.com',
+        repository: 'testrepo',
+        namespace: 'testorg',
+        confirmed: false,
+      },
+      {
+        email: 'user2@redhat.com',
+        repository: 'testrepo',
+        namespace: 'testorg',
+        confirmed: true,
+      },
+    ];
+    cy.intercept(
+      'GET',
+      '/api/v1/repository/testorg/testrepo/authorizedemail/user2@redhat.com',
+      (req) => req.reply((res) => res.send(200, responses.shift())),
+    ).as('getAuthorizedEmail');
+    cy.intercept(
+      'POST',
+      '/api/v1/repository/testorg/testrepo/authorizedemail/user2@redhat.com',
+      {},
+    ).as('sendConfirmationEmail');
+    cy.intercept(
+      'POST',
+      '/api/v1/repository/testorg/testrepo/notification/',
+      {},
+    ).as('createNotification');
+    cy.contains('Create Notification').click();
+    cy.get('#create-notification-form').within(() => {
+      cy.contains('Select event').click();
+      cy.contains('Push to Repository').click();
+      cy.contains('Select method').click();
+      cy.contains('Email Notification').click();
+      cy.get('#notification-email').type('user2@redhat.com');
+      cy.get('#notification-title').type('newnotification');
+      cy.contains('Submit').click();
+    });
+    cy.contains('Email Authorization').should('exist');
+    cy.contains(
+      'The email address user2@redhat.com has not been authorized to recieve notifications from this repository. Please click ‘Send Authorized Email‘ to start the authorization process.',
+    ).should('exist');
+    cy.get('button').contains('Send Authorized Email').click();
+    cy.contains(
+      'An email has been sent to user2@redhat.com. Please click the link contained in the email.',
+    ).should('exist');
+    cy.wait('@createNotification', {timeout: 20000});
+    cy.get('@createNotification')
+      .its('request.body')
+      .should('deep.equal', {
+        config: {
+          email: 'user2@redhat.com',
+        },
+        event: 'repo_push',
+        eventConfig: {},
+        event_config: {},
+        method: 'email',
+        title: 'newnotification',
+      });
+  });
+});

--- a/cypress/e2e/repository-notifications.cy.ts
+++ b/cypress/e2e/repository-notifications.cy.ts
@@ -12,6 +12,7 @@ describe('Repository Settings - Notifications', () => {
     cy.intercept('GET', '/config', (req) =>
       req.reply((res) => {
         res.body.features['UI_V2_REPO_SETTINGS'] = true;
+        res.body.features['MAILING'] = true;
         return res;
       }),
     ).as('getConfig');

--- a/cypress/e2e/repository-permissions.cy.ts
+++ b/cypress/e2e/repository-permissions.cy.ts
@@ -1,168 +1,174 @@
-// TODO: Uncomment once custom Quay config has been implemented in CI
-// /// <reference types="cypress" />
+/// <reference types="cypress" />
 
-// describe('Repository Details Page', () => {
-//   beforeEach(() => {
-//     cy.exec('npm run quay:seed');
-//     cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
-//       .then((response) => response.body.csrf_token)
-//       .then((token) => {
-//         cy.loginByCSRF(token);
-//       });
-//     cy.visit('/repository/testorg/testrepo?tab=settings');
-//   });
+describe('Repository Settings - Permissions', () => {
+  beforeEach(() => {
+    cy.exec('npm run quay:seed');
+    cy.request('GET', `${Cypress.env('REACT_QUAY_APP_API_URL')}/csrf_token`)
+      .then((response) => response.body.csrf_token)
+      .then((token) => {
+        cy.loginByCSRF(token);
+      });
+    // Enable the repository settings feature
+    cy.intercept('GET', '/config', (req) =>
+      req.reply((res) => {
+        res.body.features['UI_V2_REPO_SETTINGS'] = true;
+        return res;
+      }),
+    ).as('getConfig');
+    cy.visit('/repository/testorg/testrepo?tab=settings');
+  });
 
-//   it('Renders permissions', () => {
-//     const user1Row = cy.get('tr:contains("user1")');
-//     user1Row.within(() => {
-//       cy.get(`[data-label="membername"]`).should('have.text', 'user1');
-//       cy.get(`[data-label="type"]`).should('have.text', 'user');
-//       cy.get(`[data-label="role"]`).should('have.text', 'admin');
-//     });
-//     const robotRow = cy.get('tr:contains("testorg+testrobot")');
-//     robotRow.within(() => {
-//       cy.get(`[data-label="membername"]`).should(
-//         'have.text',
-//         'testorg+testrobot',
-//       );
-//       cy.get(`[data-label="type"]`).should('have.text', 'robot');
-//       cy.get(`[data-label="role"]`).should('have.text', 'read');
-//     });
-//     const teamRow = cy.get('tr:contains("testteam")');
-//     teamRow.within(() => {
-//       cy.get(`[data-label="membername"]`).should('have.text', 'testteam');
-//       cy.get(`[data-label="type"]`).should('have.text', 'team');
-//       cy.get(`[data-label="role"]`).should('have.text', 'read');
-//     });
-//   });
+  it('Renders permissions', () => {
+    const user1Row = cy.get('tr:contains("user1")');
+    user1Row.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'user1');
+      cy.get(`[data-label="type"]`).should('have.text', 'user');
+      cy.get(`[data-label="role"]`).should('have.text', 'admin');
+    });
+    const robotRow = cy.get('tr:contains("testorg+testrobot")');
+    robotRow.within(() => {
+      cy.get(`[data-label="membername"]`).should(
+        'have.text',
+        'testorg+testrobot',
+      );
+      cy.get(`[data-label="type"]`).should('have.text', 'robot');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+    const teamRow = cy.get('tr:contains("testteam")');
+    teamRow.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'testteam');
+      cy.get(`[data-label="type"]`).should('have.text', 'team');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+  });
 
-//   it('Changes user/robot/team permissions inline', () => {
-//     const user1Row = cy.get('tr:contains("user1")');
-//     user1Row.within(() => {
-//       cy.contains('admin').click();
-//       cy.contains('Read').click();
-//       cy.get(`[data-label="role"]`).should('have.text', 'read');
-//     });
-//     const robotRow = cy.get('tr:contains("testorg+testrobot")');
-//     robotRow.within(() => {
-//       cy.contains('read').click();
-//       cy.contains('Write').click();
-//       cy.get(`[data-label="role"]`).should('have.text', 'write');
-//     });
-//     const teamRow = cy.get('tr:contains("testteam")');
-//     teamRow.within(() => {
-//       cy.contains('read').click();
-//       cy.contains('Write').click();
-//       cy.get(`[data-label="role"]`).should('have.text', 'write');
-//     });
-//   });
+  it('Changes user/robot/team permissions inline', () => {
+    const user1Row = cy.get('tr:contains("user1")');
+    user1Row.within(() => {
+      cy.contains('admin').click();
+      cy.contains('Read').click();
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+    const robotRow = cy.get('tr:contains("testorg+testrobot")');
+    robotRow.within(() => {
+      cy.contains('read').click();
+      cy.contains('Write').click();
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+    const teamRow = cy.get('tr:contains("testteam")');
+    teamRow.within(() => {
+      cy.contains('read').click();
+      cy.contains('Write').click();
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+  });
 
-//   it('Deletes user/robot/team permission inline', () => {
-//     const user1Row = cy.get('tr:contains("user1")');
-//     user1Row.within(() => {
-//       cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
-//       cy.contains('Delete Permission').click();
-//       cy.contains('user1').should('not.exist');
-//     });
-//     const robotRow = cy.get('tr:contains("testorg+testrobot")');
-//     robotRow.within(() => {
-//       cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
-//       cy.contains('Delete Permission').click();
-//       cy.contains('testorg+testrobot').should('not.exist');
-//     });
-//     const teamRow = cy.get('tr:contains("testteam")');
-//     teamRow.within(() => {
-//       cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
-//       cy.contains('Delete Permission').click();
-//       cy.contains('testteam').should('not.exist');
-//     });
-//   });
+  it('Deletes user/robot/team permission inline', () => {
+    const user1Row = cy.get('tr:contains("user1")');
+    user1Row.within(() => {
+      cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
+      cy.contains('Delete Permission').click();
+      cy.contains('user1').should('not.exist');
+    });
+    const robotRow = cy.get('tr:contains("testorg+testrobot")');
+    robotRow.within(() => {
+      cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
+      cy.contains('Delete Permission').click();
+      cy.contains('testorg+testrobot').should('not.exist');
+    });
+    const teamRow = cy.get('tr:contains("testteam")');
+    teamRow.within(() => {
+      cy.get('[data-label="kebab"]').within(() => cy.get('button').click());
+      cy.contains('Delete Permission').click();
+      cy.contains('testteam').should('not.exist');
+    });
+  });
 
-//   it('Bulk deletes permissions', () => {
-//     cy.contains('1 - 3 of 3').should('exist');
-//     cy.get('#permissions-select-all').click();
-//     cy.contains('Actions').click();
-//     cy.contains('Delete').click();
-//     cy.get('table').within(() => {
-//       cy.contains('user1').should('not.exist');
-//       cy.contains('testorg+testrobot').should('not.exist');
-//       cy.contains('testteam').should('not.exist');
-//     });
-//   });
+  it('Bulk deletes permissions', () => {
+    cy.contains('1 - 3 of 3').should('exist');
+    cy.get('#permissions-select-all').click();
+    cy.contains('Actions').click();
+    cy.contains('Delete').click();
+    cy.get('table').within(() => {
+      cy.contains('user1').should('not.exist');
+      cy.contains('testorg+testrobot').should('not.exist');
+      cy.contains('testteam').should('not.exist');
+    });
+  });
 
-//   it('Bulk changes permissions', () => {
-//     cy.contains('1 - 3 of 3').should('exist');
-//     cy.get('#permissions-select-all').click();
-//     cy.contains('Actions').click();
-//     cy.contains('Change Permissions').click();
-//     cy.get('#change-permissions-menu').within(() => {
-//       cy.contains('Write').click();
-//     });
-//     const user1Row = cy.get('tr:contains("user1")');
-//     user1Row.within(() => {
-//       cy.get(`[data-label="membername"]`).should('have.text', 'user1');
-//       cy.get(`[data-label="role"]`).should('have.text', 'write');
-//     });
-//     const robotRow = cy.get('tr:contains("testorg+testrobot")');
-//     robotRow.within(() => {
-//       cy.get(`[data-label="membername"]`).should(
-//         'have.text',
-//         'testorg+testrobot',
-//       );
-//       cy.get(`[data-label="role"]`).should('have.text', 'write');
-//     });
-//     const teamRow = cy.get('tr:contains("testteam")');
-//     teamRow.within(() => {
-//       cy.get(`[data-label="membername"]`).should('have.text', 'testteam');
-//       cy.get(`[data-label="role"]`).should('have.text', 'write');
-//     });
-//   });
+  it('Bulk changes permissions', () => {
+    cy.contains('1 - 3 of 3').should('exist');
+    cy.get('#permissions-select-all').click();
+    cy.contains('Actions').click();
+    cy.contains('Change Permissions').click();
+    cy.get('#change-permissions-menu').within(() => {
+      cy.contains('Write').click();
+    });
+    const user1Row = cy.get('tr:contains("user1")');
+    user1Row.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'user1');
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+    const robotRow = cy.get('tr:contains("testorg+testrobot")');
+    robotRow.within(() => {
+      cy.get(`[data-label="membername"]`).should(
+        'have.text',
+        'testorg+testrobot',
+      );
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+    const teamRow = cy.get('tr:contains("testteam")');
+    teamRow.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'testteam');
+      cy.get(`[data-label="role"]`).should('have.text', 'write');
+    });
+  });
 
-//   it('Adds user/robot/team permission', () => {
-//     cy.contains('Add Permissions').click();
-//     cy.get('#add-permission-form').within(() => {
-//       cy.get('input').type('user');
-//       cy.contains('user2').click();
-//       cy.contains('admin').click();
-//       cy.contains('Read').click();
-//       cy.contains('Submit').click();
-//     });
-//     const user2Row = cy.get('tr:contains("user2")');
-//     user2Row.within(() => {
-//       cy.get(`[data-label="membername"]`).should('have.text', 'user2');
-//       cy.get(`[data-label="type"]`).should('have.text', 'user');
-//       cy.get(`[data-label="role"]`).should('have.text', 'read');
-//     });
-//     cy.contains('Add Permissions').click();
-//     cy.get('#add-permission-form').within(() => {
-//       cy.get('input').type('test');
-//       cy.contains('testorg+testrobot2').click();
-//       cy.contains('admin').click();
-//       cy.contains('Read').click();
-//       cy.contains('Submit').click();
-//     });
-//     const testrobot3Row = cy.get('tr:contains("testorg+testrobot2")');
-//     testrobot3Row.within(() => {
-//       cy.get(`[data-label="membername"]`).should(
-//         'have.text',
-//         'testorg+testrobot2',
-//       );
-//       cy.get(`[data-label="type"]`).should('have.text', 'robot');
-//       cy.get(`[data-label="role"]`).should('have.text', 'read');
-//     });
-//     cy.contains('Add Permissions').click();
-//     cy.get('#add-permission-form').within(() => {
-//       cy.get('input').type('test');
-//       cy.contains('testteam2').click();
-//       cy.contains('admin').click();
-//       cy.contains('Read').click();
-//       cy.contains('Submit').click();
-//     });
-//     const testteam2Row = cy.get('tr:contains("testteam2")');
-//     testteam2Row.within(() => {
-//       cy.get(`[data-label="membername"]`).should('have.text', 'testteam2');
-//       cy.get(`[data-label="type"]`).should('have.text', 'team');
-//       cy.get(`[data-label="role"]`).should('have.text', 'read');
-//     });
-//   });
-// });
+  it('Adds user/robot/team permission', () => {
+    cy.contains('Add Permissions').click();
+    cy.get('#add-permission-form').within(() => {
+      cy.get('input').type('user');
+      cy.contains('user2').click();
+      cy.contains('admin').click();
+      cy.contains('Read').click();
+      cy.contains('Submit').click();
+    });
+    const user2Row = cy.get('tr:contains("user2")');
+    user2Row.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'user2');
+      cy.get(`[data-label="type"]`).should('have.text', 'user');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+    cy.contains('Add Permissions').click();
+    cy.get('#add-permission-form').within(() => {
+      cy.get('input').type('test');
+      cy.contains('testorg+testrobot2').click();
+      cy.contains('admin').click();
+      cy.contains('Read').click();
+      cy.contains('Submit').click();
+    });
+    const testrobot3Row = cy.get('tr:contains("testorg+testrobot2")');
+    testrobot3Row.within(() => {
+      cy.get(`[data-label="membername"]`).should(
+        'have.text',
+        'testorg+testrobot2',
+      );
+      cy.get(`[data-label="type"]`).should('have.text', 'robot');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+    cy.contains('Add Permissions').click();
+    cy.get('#add-permission-form').within(() => {
+      cy.get('input').type('test');
+      cy.contains('testteam2').click();
+      cy.contains('admin').click();
+      cy.contains('Read').click();
+      cy.contains('Submit').click();
+    });
+    const testteam2Row = cy.get('tr:contains("testteam2")');
+    testteam2Row.within(() => {
+      cy.get(`[data-label="membername"]`).should('have.text', 'testteam2');
+      cy.get(`[data-label="type"]`).should('have.text', 'team');
+      cy.get(`[data-label="role"]`).should('have.text', 'read');
+    });
+  });
+});

--- a/cypress/test/quay-db-data.txt
+++ b/cypress/test/quay-db-data.txt
@@ -5244,7 +5244,7 @@ COPY public.accesstokenkind (id, name) FROM stdin;
 --
 
 COPY public.alembic_version (version_num) FROM stdin;
-2d66ad598b56
+7bca88923f2c
 \.
 
 
@@ -5608,6 +5608,11 @@ COPY public.logentry3 (id, kind_id, account_id, performer_id, repository_id, dat
 17	22	28	1	5	2022-11-30 21:23:26.32246	172.20.0.1	{"username": "user2", "repo": "testrepo", "namespace": "testorg"}
 18	15	28	1	\N	2022-11-30 21:23:53.670728	172.20.0.1	{"robot": "testrobot2", "description": "", "unstructured_metadata": null}
 19	32	28	1	\N	2022-11-30 21:24:13.085006	172.20.0.1	{"team": "testteam2"}
+20	6	28	1	5	2022-12-14 18:50:25.878608	172.18.0.1	{"repo": "testrepo", "namespace": "testorg", "notification_id": "a5a83554-b024-4522-8b63-509266b1e45e", "event": "build_failure", "method": "flowdock"}
+21	6	28	1	5	2022-12-14 18:50:56.412989	172.18.0.1	{"repo": "testrepo", "namespace": "testorg", "notification_id": "2a4aeb62-3bea-4bb7-83ca-75a34dec3367", "event": "build_queued", "method": "hipchat"}
+22	6	28	1	5	2022-12-14 18:51:19.966575	172.18.0.1	{"repo": "testrepo", "namespace": "testorg", "notification_id": "70a8f966-1dc1-47b8-9b51-3cf71d0f9ad2", "event": "vulnerability_found", "method": "slack"}
+23	6	28	1	5	2022-12-14 18:53:14.486603	172.18.0.1	{"repo": "testrepo", "namespace": "testorg", "notification_id": "1efd38da-6ab4-4e09-822d-3b1742a00b1c", "event": "repo_mirror_sync_started", "method": "webhook"}
+24	6	28	1	5	2022-12-14 18:54:27.270995	172.18.0.1	{"repo": "testrepo", "namespace": "testorg", "notification_id": "1d07e6db-be20-405a-8780-9d83bf1d16da", "event": "repo_mirror_sync_success", "method": "email"}
 \.
 
 
@@ -5691,6 +5696,8 @@ COPY public.logentrykind (id, name) FROM stdin;
 73	repo_mirror_sync_test_failed
 74	repo_mirror_sync_test_started
 75	change_repo_state
+76	create_proxy_cache_config
+77	delete_proxy_cache_config
 \.
 
 
@@ -5942,8 +5949,8 @@ COPY public.quayservice (id, name) FROM stdin;
 --
 
 COPY public.queueitem (id, queue_name, body, available_after, available, processing_expires, retries_remaining, state_id) FROM stdin;
-1	namespacegc/2/	{"marker_id": 1, "original_username": "quay"}	2022-11-30 21:26:51.497982	t	2022-12-01 00:21:51.470842	5	a7c201f0-a472-48a7-8032-65e9ba2c766f
-2	namespacegc/3/	{"marker_id": 2, "original_username": "clair"}	2022-11-30 21:26:56.605709	t	2022-12-01 00:21:56.51308	5	c54c092e-4c5b-4c14-a687-6fa70a2b79c5
+2	namespacegc/3/	{"marker_id": 2, "original_username": "clair"}	2022-12-14 18:56:59.815905	t	2022-12-14 21:51:59.768648	5	960e152c-7f72-4913-9077-be4d06d4bc0d
+1	namespacegc/2/	{"marker_id": 1, "original_username": "quay"}	2022-12-14 18:57:04.89912	t	2022-12-14 21:52:04.832757	5	ef3aadd2-df78-49ac-9ff9-3145cae338ae
 \.
 
 
@@ -6012,6 +6019,7 @@ COPY public.repositoryactioncount (id, repository_id, count, date) FROM stdin;
 --
 
 COPY public.repositoryauthorizedemail (id, repository_id, email, code, confirmed) FROM stdin;
+1	5	user1@redhat.com	J9VE21W29UAZ8UU0	t
 \.
 
 
@@ -6046,6 +6054,11 @@ COPY public.repositorykind (id, name) FROM stdin;
 --
 
 COPY public.repositorynotification (id, uuid, repository_id, event_id, method_id, title, config_json, event_config_json, number_of_failures) FROM stdin;
+1	a5a83554-b024-4522-8b63-509266b1e45e	5	1	2		{"flow_api_token": "testtoken"}	{}	0
+2	2a4aeb62-3bea-4bb7-83ca-75a34dec3367	5	2	3	hipchat-notification	{"notification_token": "testtoken", "room_id": "123"}	{}	0
+3	70a8f966-1dc1-47b8-9b51-3cf71d0f9ad2	5	6	5	slack-notification	{"url": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"}	{}	3
+4	1efd38da-6ab4-4e09-822d-3b1742a00b1c	5	8	6	webhook-notification	{"url": "https://doesnotexist", "template": "{\\"foo\\":\\"bar\\"}"}	{}	3
+5	1d07e6db-be20-405a-8780-9d83bf1d16da	5	9	1	email-notification	{"email": "user1@redhat.com"}	{}	3
 \.
 
 
@@ -6134,10 +6147,7 @@ COPY public.role (id, name) FROM stdin;
 --
 
 COPY public.servicekey (id, name, kid, service, jwk, metadata, created_date, expiration_date, rotation_duration, approval_id) FROM stdin;
-3	http://localhost:8080	wymy28RvVXS0McHaIj1wHjC1EyhlDczyo4gw0etqOX0	quay	{"n": "vjW8tgIpHoHptN3RslleeLDBbGeQmh_Usp5TvKWDOKJZFOQboxaqXCnFVsB_Ua_HX0Qxz5Rk1LnO1s0rWHwDenoHG_Yt_ph5gd97H2zLQdSt6oZ2dGFYvBIK8-MbZ-vzk5vN7Vgg7BQleIEl-pmeHBhlv9jzAnoFCToEgsSvT72FU0MNM1bx_cKdMdHDxp8mCbFxgwxfecHznf50MJVm9SdDedtFvJ8gUf_QjWdhxQ5JxqwmwYNqp5-h4RyPKySuTXtcwb2-tIIr0Rux3IS4DCnWEykM3BeD_grQMRkysS_kwsMWuGPOk72hRk3Q9Ug01tV5wD4XzzuuTdGFinzKrQ", "e": "AQAB", "kty": "RSA", "kid": "wymy28RvVXS0McHaIj1wHjC1EyhlDczyo4gw0etqOX0"}	{"created_by": "CLI tool"}	2022-11-15 13:34:27.001785	2022-11-15 15:34:26.969059	\N	3
-4	http://localhost:8080	ZN_lSn1MoxnNCzytTOzLMWCk-orZMuADii9Sq-8x-IY	quay	{"n": "nl6bWQNChlr6m7uK2h7fSwAHwYKrGLNdX8SvqHkvtNknxKCIsEpFIr7a_Fe3ZTk-vyB4aT-m32LiL8XXvptI25BnpZ2zCPhZDAM4rtH0E8AyJ0C31JpNNhUtq_fjFhgnxkCiO_zDdBtUP8r-TafHxL9nb9NmsgYblXQY4JGNtCUbF_r5OmJZQ7VHzUveDP15af62hKMeIVt9BmHHqozrKgac_EKlh1JAAckQrpJHhHt77OUw08hFDXmjS6Kbqi8y99unwPdMCKi4fHC-cRN5Rav02JLTFy8CpT8C10P-elgVykaHWWyb-IJtXKfP3brgfFvTFJmm33N6UhINr_lf6Q", "e": "AQAB", "kty": "RSA", "kid": "ZN_lSn1MoxnNCzytTOzLMWCk-orZMuADii9Sq-8x-IY"}	{"created_by": "CLI tool"}	2022-11-21 18:40:02.350605	2022-11-21 20:40:02.300317	\N	4
-5	http://localhost:8080	W5XCs7v0wlWNdxINw__qqEGaaHA1REQDheowzey_mwk	quay	{"n": "1TPNyRNsQQgOc0Mb2uFJRbWn_a--Tfl62zYDtXS5X1C45S5PSwqnKQalLPudSaCvjV9E4Ez53OgEFLmq7At3r-6zuIfWsSnpDjYAjcH7yMCmreJ45b1TWOxOXLUpNj7XS4Lh1akVaHgJ12kfIztwqIYm2f4GGmKdzwXoOMvPEY-3ph7vmGfOdURZLM9hT-0mx5tjFCeC1oh1GOdwLn5i0UJd3yXyt0kWC6xV5nksUCr01QOg8wSyxyCelR2-ohVr40H5znsgHfPIQe6jhL6o9yCzoYSVDmD5vRmBdvTlAIP1DGhhWxFVGHGGPNw_Qnzlib3Iui2NbHUHBDbt2G0Ezw", "e": "AQAB", "kty": "RSA", "kid": "W5XCs7v0wlWNdxINw__qqEGaaHA1REQDheowzey_mwk"}	{"created_by": "CLI tool"}	2022-11-21 18:43:45.386442	2022-11-21 20:43:45.335226	\N	5
-6	http://localhost:8080	tRXwIjs2xAQHUZ3Qu0Akdj94ghiGT0SC0uiztOQKV0k	quay	{"n": "vMUcyTKhjv7fJY5CBsodDchHfdMV6hxprj4uoGV-0FWnRR4ZAH4-csSzlkIihMvRY095YbHgi9bJJp03Mkcz9juMHN7tvA_Ew328f6hP6aExEBfTFbB49Ky2cuKrDL0hi0waqYOfm35JVb2xY4yHTdXPaMa9IvcEqsaM4ih2T5GRfKneCC35ffdufqBYvmVBrM0jAXLGvi7K2_UFBcH2pjm_aEJ0EzNhQEqgig2z6mbb-w77CQYjDfrrwPIMfsY4fIyCkQjzAe-7Yt5Cuf_TH7BkPv1ZNnCfo4kPSOeV6MY7tygaZXxkvKINU24YXLgETmHPasqZ7fttPR5P6VimNw", "e": "AQAB", "kty": "RSA", "kid": "tRXwIjs2xAQHUZ3Qu0Akdj94ghiGT0SC0uiztOQKV0k"}	{"created_by": "CLI tool"}	2022-11-21 18:47:59.573251	2022-11-21 20:47:59.495676	\N	6
+7	http://localhost:8080	P8HCej8ZzT3H5ZYy7MxTvhg1sHbcala08GAhxKi2bBw	quay	{"n": "kDMkzNJQ-5dIQESnv0C08ngyDkxlS_RmCm_261oE8PTmimZx4yLxTOqreuW9XIspHaWwjlGUno-R0-4jP5eio0O09TKMS4vc9btPbNM6afhnzn7zVs5qvgdgmESTMtxuV03e8axLxEHY_jM-RKgSxgfB-akC3THj0N-7wRBZl3k7l4CWi4UUDsrHl5RUQSwyA75HRGaK5pDQFeJuIiP2ePKuKCMHOKunqXrUVrsIKScn47i4fpJyhICYTHhHJBGp8Q9UTRSZ57aaIhpjOe3gV3_gGw_nFTD1gOA-IWfmhr70z1SPI52DqLxweq4Ye1L1NiT8miRvVYSlFCszXQJVDw", "e": "AQAB", "kty": "RSA", "kid": "P8HCej8ZzT3H5ZYy7MxTvhg1sHbcala08GAhxKi2bBw"}	{"created_by": "CLI tool"}	2022-12-14 18:48:53.987846	2022-12-14 20:48:53.80133	\N	7
 \.
 
 
@@ -6151,6 +6161,7 @@ COPY public.servicekeyapproval (id, approver_id, approval_type, approved_date, n
 4	\N	ServiceKeyApprovalType.AUTOMATIC	2022-11-21 18:40:02.364779	
 5	\N	ServiceKeyApprovalType.AUTOMATIC	2022-11-21 18:43:45.399899	
 6	\N	ServiceKeyApprovalType.AUTOMATIC	2022-11-21 18:47:59.585515	
+7	\N	ServiceKeyApprovalType.AUTOMATIC	2022-12-14 18:48:54.002141	
 \.
 
 
@@ -6671,7 +6682,7 @@ SELECT pg_catalog.setval('public.logentry2_id_seq', 1, false);
 -- Name: logentry3_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.logentry3_id_seq', 19, true);
+SELECT pg_catalog.setval('public.logentry3_id_seq', 24, true);
 
 
 --
@@ -6685,7 +6696,7 @@ SELECT pg_catalog.setval('public.logentry_id_seq', 1, false);
 -- Name: logentrykind_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.logentrykind_id_seq', 75, true);
+SELECT pg_catalog.setval('public.logentrykind_id_seq', 77, true);
 
 
 --
@@ -6762,7 +6773,7 @@ SELECT pg_catalog.setval('public.namespacegeorestriction_id_seq', 1, false);
 -- Name: notification_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.notification_id_seq', 1, false);
+SELECT pg_catalog.setval('public.notification_id_seq', 1, true);
 
 
 --
@@ -6881,7 +6892,7 @@ SELECT pg_catalog.setval('public.repositoryactioncount_id_seq', 5, true);
 -- Name: repositoryauthorizedemail_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.repositoryauthorizedemail_id_seq', 1, false);
+SELECT pg_catalog.setval('public.repositoryauthorizedemail_id_seq', 1, true);
 
 
 --
@@ -6909,7 +6920,7 @@ SELECT pg_catalog.setval('public.repositorykind_id_seq', 1, false);
 -- Name: repositorynotification_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.repositorynotification_id_seq', 1, false);
+SELECT pg_catalog.setval('public.repositorynotification_id_seq', 5, true);
 
 
 --
@@ -6965,14 +6976,14 @@ SELECT pg_catalog.setval('public.role_id_seq', 3, true);
 -- Name: servicekey_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.servicekey_id_seq', 6, true);
+SELECT pg_catalog.setval('public.servicekey_id_seq', 7, true);
 
 
 --
 -- Name: servicekeyapproval_id_seq; Type: SEQUENCE SET; Schema: public; Owner: quay
 --
 
-SELECT pg_catalog.setval('public.servicekeyapproval_id_seq', 6, true);
+SELECT pg_catalog.setval('public.servicekeyapproval_id_seq', 7, true);
 
 
 --

--- a/src/components/EntitySearch.tsx
+++ b/src/components/EntitySearch.tsx
@@ -1,0 +1,66 @@
+import {Select, SelectOption, SelectVariant} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import {useEntities} from 'src/hooks/UseEntities';
+import {Entity, getMemberType} from 'src/resources/UserResource';
+
+export default function EntitySearch(props: EntitySearchProps) {
+  const [selectedEntityName, setSelectedEntityName] = useState<string>();
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const {entities, isError, searchTerm, setSearchTerm} = useEntities(props.org);
+
+  useEffect(() => {
+    if (selectedEntityName != undefined && selectedEntityName != '') {
+      const filteredEntity = entities.filter(
+        (e) => e.name === selectedEntityName,
+      );
+      const selectedEntity =
+        filteredEntity.length > 0 ? filteredEntity[0] : null;
+      props.onSelect(selectedEntity);
+    }
+  }, [selectedEntityName]);
+
+  useEffect(() => {
+    if (isError) {
+      props.onError();
+    }
+  }, [isError]);
+
+  return (
+    <Select
+      toggleId={props.id ? props.id : 'entity-search'}
+      isOpen={isOpen}
+      selections={searchTerm}
+      onSelect={(e, value) => {
+        setSearchTerm(value as string);
+        setSelectedEntityName(value as string);
+        setIsOpen(!isOpen);
+      }}
+      onToggle={() => {
+        setIsOpen(!isOpen);
+      }}
+      variant={SelectVariant.typeahead}
+      onTypeaheadInputChanged={(value) => {
+        setSearchTerm(value);
+      }}
+      shouldResetOnSelect={true}
+      onClear={() => {
+        setSearchTerm('');
+      }}
+    >
+      {entities.map((e) => (
+        <SelectOption
+          key={e.name}
+          value={e.name}
+          description={getMemberType(e)}
+        />
+      ))}
+    </Select>
+  );
+}
+
+interface EntitySearchProps {
+  org: string;
+  onSelect: (entity: Entity) => void;
+  onError?: () => void;
+  id?: string;
+}

--- a/src/hooks/UseAuthorizedEmails.ts
+++ b/src/hooks/UseAuthorizedEmails.ts
@@ -1,0 +1,64 @@
+import {
+  AuthorizedEmail,
+  fetchAuthorizedEmail,
+  sendAuthorizedEmail,
+} from 'src/resources/AuthorizedEmailResource';
+import {AxiosError} from 'axios';
+import {useState} from 'react';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+
+export interface AuthorizedEmailStatus {
+  emailData: AuthorizedEmail;
+  exists: boolean;
+  error: Error;
+}
+
+export function useAuthorizedEmails(org: string, repo: string) {
+  const [pollEmail, setPollEmail] = useState<string>('');
+  const [emailConfirmed, setEmailConfirmed] = useState<boolean>(false);
+  const polling = pollEmail != '';
+  const startPolling = (email: string) => setPollEmail(email);
+  const stopPolling = () => setPollEmail('');
+  const resetEmailConfirmed = () => setEmailConfirmed(false);
+
+  const {isError: errorPolling} = useQuery(
+    ['pollauthorizedemail', org, repo, pollEmail],
+    () => fetchAuthorizedEmail(org, repo, pollEmail),
+    {
+      enabled: polling,
+      refetchInterval: (emailData: AuthorizedEmail) => {
+        if (emailData != null && emailData.confirmed) {
+          setEmailConfirmed(true);
+          stopPolling();
+          return false;
+        } else {
+          return 5000;
+        }
+      },
+      onError: () => stopPolling(),
+    },
+  );
+
+  const {
+    mutate: sendEmail,
+    isError: errorSendingEmail,
+    isSuccess: successSendingEmail,
+    reset,
+  } = useMutation(async (email: string) =>
+    sendAuthorizedEmail(org, repo, email),
+  );
+
+  return {
+    polling: polling,
+    errorPolling: errorPolling,
+    startPolling: startPolling,
+    stopPolling: stopPolling,
+    emailConfirmed: emailConfirmed,
+    resetEmailConfirmed: resetEmailConfirmed,
+
+    sendAuthorizedEmail: sendEmail,
+    successSendingAuthorizedEmail: successSendingEmail,
+    errorSendingAuthorizedEmail: errorSendingEmail,
+    resetSendAuthorizationEmail: reset,
+  };
+}

--- a/src/hooks/UseEvents.ts
+++ b/src/hooks/UseEvents.ts
@@ -1,0 +1,80 @@
+import {NotificationEventType} from 'src/resources/NotificationResource';
+import {useQuayConfig} from './UseQuayConfig';
+
+export interface NotificationEvent {
+  type: NotificationEventType;
+  title: string;
+  icon: React.ReactNode;
+  enabled: boolean;
+}
+
+export function useEvents() {
+  const config = useQuayConfig();
+  // TODO: Implement icons
+  const events: NotificationEvent[] = [
+    {
+      type: NotificationEventType.repoPush,
+      title: 'Push to Repository',
+      icon: null,
+      enabled: true,
+    },
+    {
+      type: NotificationEventType.vulnFound,
+      title: 'Package Vulnerability Found',
+      icon: null,
+      enabled: config?.features.SECURITY_SCANNER,
+    },
+    {
+      type: NotificationEventType.buildFailure,
+      title: 'Image build failed',
+      icon: null,
+      enabled: config?.features.BUILD_SUPPORT,
+    },
+    {
+      type: NotificationEventType.buildQueued,
+      title: 'Image build queued',
+      icon: null,
+      enabled: config?.features.BUILD_SUPPORT,
+    },
+    {
+      type: NotificationEventType.buildStart,
+      title: 'Image build started',
+      icon: null,
+      enabled: config?.features.BUILD_SUPPORT,
+    },
+    {
+      type: NotificationEventType.buildSuccess,
+      title: 'Image build success',
+      icon: null,
+      enabled: config?.features.BUILD_SUPPORT,
+    },
+    {
+      type: NotificationEventType.buildCancelled,
+      title: 'Image build cancelled',
+      icon: null,
+      enabled: config?.features.BUILD_SUPPORT,
+    },
+    {
+      type: NotificationEventType.mirrorStarted,
+      title: 'Repository mirror started',
+      icon: null,
+      enabled: config?.features.REPO_MIRROR,
+    },
+    {
+      type: NotificationEventType.mirrorSuccess,
+      title: 'Repository mirror successful',
+      icon: null,
+      enabled: config?.features.REPO_MIRROR,
+    },
+    {
+      type: NotificationEventType.mirrorFailed,
+      title: 'Repository mirror unsuccessful',
+      icon: null,
+      enabled: config?.features.REPO_MIRROR,
+    },
+  ];
+
+  return {
+    events: events,
+  };
+}

--- a/src/hooks/UseNotificationMethods.ts
+++ b/src/hooks/UseNotificationMethods.ts
@@ -1,0 +1,47 @@
+import {NotificationMethodType} from 'src/resources/NotificationResource';
+import {useQuayConfig} from './UseQuayConfig';
+
+export interface NotificationMethod {
+  type: NotificationMethodType;
+  title: string;
+  enabled: boolean;
+}
+
+export function useNotificationMethods() {
+  const config = useQuayConfig();
+  const notificationMethods: NotificationMethod[] = [
+    {
+      type: NotificationMethodType.email,
+      title: 'Email Notification',
+      enabled: config?.features.MAILING,
+    },
+    {
+      type: NotificationMethodType.flowdock,
+      title: 'Flowdock Team Notification',
+      enabled: true,
+    },
+    {
+      type: NotificationMethodType.hipchat,
+      title: 'HipChat Room Notification',
+      enabled: true,
+    },
+    {
+      type: NotificationMethodType.quaynotification,
+      title: `${config?.config.REGISTRY_TITLE_SHORT} Notification`,
+      enabled: false, // TODO: Implemented but requires notifications in header to be created
+    },
+    {
+      type: NotificationMethodType.slack,
+      title: 'Slack Notification',
+      enabled: true,
+    },
+    {
+      type: NotificationMethodType.webhook,
+      title: 'Webhook POST',
+      enabled: true,
+    },
+  ];
+  return {
+    notificationMethods: notificationMethods,
+  };
+}

--- a/src/hooks/UseNotifications.ts
+++ b/src/hooks/UseNotifications.ts
@@ -1,0 +1,93 @@
+import {useQuery} from '@tanstack/react-query';
+import {useState} from 'react';
+import {
+  fetchNotifications,
+  isNotificationDisabled,
+  isNotificationEnabled,
+  NotificationEventType,
+} from 'src/resources/NotificationResource';
+
+export enum NotifiationStatus {
+  enabled = 'enabled',
+  disabled = 'disabled',
+}
+
+export interface NotificationFilter {
+  event: NotificationEventType[];
+  status: NotifiationStatus[];
+}
+
+export function useNotifications(org: string, repo: string) {
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(10);
+  const [filter, setFilter] = useState<NotificationFilter>({
+    event: [],
+    status: [],
+  });
+
+  const resetFilter = (field = null) => {
+    if (field != null) {
+      setFilter((prev) => ({...prev, [field]: []}));
+    } else {
+      setFilter({
+        event: [],
+        status: [],
+      });
+    }
+  };
+
+  const {
+    data: notifications,
+    isError: error,
+    isLoading: loading,
+    isPlaceholderData: isPlaceholderData,
+  } = useQuery(
+    ['reponotifications', org, repo],
+    () => fetchNotifications(org, repo),
+    {
+      placeholderData: [],
+    },
+  );
+
+  let filteredNotifications = notifications;
+  if (filter.event.length > 0) {
+    filteredNotifications = filteredNotifications.filter((n) =>
+      filter.event.includes(n.event),
+    );
+  }
+  const showEnabled = filter.status.includes(NotifiationStatus.enabled);
+  const showDisabled = filter.status.includes(NotifiationStatus.disabled);
+  if (!(showEnabled && showDisabled)) {
+    if (showEnabled) {
+      filteredNotifications = filteredNotifications.filter((n) =>
+        isNotificationEnabled(n),
+      );
+    }
+    if (showDisabled) {
+      filteredNotifications = filteredNotifications.filter((n) =>
+        isNotificationDisabled(n),
+      );
+    }
+  }
+
+  const paginatedNotifications = filteredNotifications?.slice(
+    page * perPage - perPage,
+    page * perPage - perPage + perPage,
+  );
+
+  return {
+    notifications: notifications,
+    paginatedNotifications: paginatedNotifications,
+    loading: loading || isPlaceholderData,
+    error: error,
+
+    page: page,
+    setPage: setPage,
+    perPage: perPage,
+    setPerPage: setPerPage,
+
+    filter: filter,
+    setFilter: setFilter,
+    resetFilter: resetFilter,
+  };
+}

--- a/src/hooks/UseRepositoryPermissions.ts
+++ b/src/hooks/UseRepositoryPermissions.ts
@@ -6,7 +6,7 @@ import {
   fetchUserRepoPermissions,
   RepoMember,
 } from 'src/resources/RepositoryResource';
-import ColumnNames from 'src/routes/RepositoryDetails/Settings/ColumnNames';
+import {PermissionsColumnNames} from 'src/routes/RepositoryDetails/Settings/ColumnNames';
 
 enum MemberType {
   user = 'user',
@@ -19,7 +19,7 @@ export function useRepositoryPermissions(org: string, repo: string) {
   const [perPage, setPerPage] = useState(10);
   const [search, setSearch] = useState<SearchState>({
     query: '',
-    field: ColumnNames.account,
+    field: PermissionsColumnNames.account,
   });
 
   const {

--- a/src/hooks/UseUpdateNotifications.ts
+++ b/src/hooks/UseUpdateNotifications.ts
@@ -1,0 +1,89 @@
+import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {
+  bulkDeleteNotifications,
+  bulkEnableNotifications,
+  createNotification,
+  testNotification,
+} from 'src/resources/NotificationResource';
+import {RepoNotification} from 'src/resources/NotificationResource';
+
+export function useUpdateNotifications(org: string, repo: string) {
+  const queryClient = useQueryClient();
+  const {
+    mutate: create,
+    isError: errorCreatingNotification,
+    isSuccess: successCreatingNotification,
+    reset: resetCreatingNotification,
+  } = useMutation(
+    async (notification: RepoNotification) =>
+      createNotification(org, repo, notification),
+    {
+      onSuccess: (_, variables) => {
+        queryClient.invalidateQueries(['reponotifications']);
+      },
+    },
+  );
+
+  const {
+    mutate: removeNotification,
+    isError: errorDeletingNotification,
+    isSuccess: successDeletingNotification,
+    reset: resetDeletingNotification,
+  } = useMutation(
+    async (uuids: string | string[]) => {
+      uuids = Array.isArray(uuids) ? uuids : [uuids];
+      return bulkDeleteNotifications(org, repo, uuids);
+    },
+    {
+      onSuccess: (_, variables) => {
+        queryClient.invalidateQueries(['reponotifications']);
+      },
+    },
+  );
+
+  const {
+    mutate: test,
+    isError: errorTestingNotification,
+    isSuccess: successTestingNotification,
+    reset: resetTestingNotification,
+  } = useMutation(async (uuid: string) => testNotification(org, repo, uuid));
+
+  const {
+    mutate: enable,
+    isError: errorEnablingNotification,
+    isSuccess: successEnablingNotification,
+    reset: resetEnablingNotification,
+  } = useMutation(
+    async (uuids: string | string[]) => {
+      uuids = Array.isArray(uuids) ? uuids : [uuids];
+      return bulkEnableNotifications(org, repo, uuids);
+    },
+    {
+      onSuccess: (_, variables) => {
+        queryClient.invalidateQueries(['reponotifications']);
+      },
+    },
+  );
+
+  return {
+    create: create,
+    successCreatingNotification: successCreatingNotification,
+    errorCreatingNotification: errorCreatingNotification,
+    resetCreatingNotification: resetCreatingNotification,
+
+    deleteNotifications: removeNotification,
+    errorDeletingNotification: errorDeletingNotification,
+    successDeletingNotification: successDeletingNotification,
+    resetDeletingNotification: resetDeletingNotification,
+
+    test: test,
+    errorTestingNotification: errorTestingNotification,
+    successTestingNotification: successTestingNotification,
+    resetTestingNotification: resetTestingNotification,
+
+    enableNotifications: enable,
+    errorEnablingNotification: errorEnablingNotification,
+    successEnablingNotification: successEnablingNotification,
+    resetEnablingNotification: resetEnablingNotification,
+  };
+}

--- a/src/resources/AuthorizedEmailResource.ts
+++ b/src/resources/AuthorizedEmailResource.ts
@@ -1,0 +1,32 @@
+import {AxiosResponse} from 'axios';
+import axios from 'src/libs/axios';
+import {assertHttpCode} from './ErrorHandling';
+
+export interface AuthorizedEmail {
+  email: string;
+  repo: string;
+  namespace: string;
+  confirmed: boolean;
+}
+
+export async function fetchAuthorizedEmail(
+  org: string,
+  repo: string,
+  email: string,
+) {
+  const url = `/api/v1/repository/${org}/${repo}/authorizedemail/${email}`;
+  const response: AxiosResponse<AuthorizedEmail> = await axios.get(url);
+  assertHttpCode(response.status, 200);
+  return response.data;
+}
+
+export async function sendAuthorizedEmail(
+  org: string,
+  repo: string,
+  email: string,
+) {
+  const url = `/api/v1/repository/${org}/${repo}/authorizedemail/${email}`;
+  const response: AxiosResponse<AuthorizedEmail> = await axios.post(url);
+  assertHttpCode(response.status, 200);
+  return response.data;
+}

--- a/src/resources/NotificationResource.ts
+++ b/src/resources/NotificationResource.ts
@@ -1,0 +1,126 @@
+import {AxiosResponse} from 'axios';
+import axios from 'src/libs/axios';
+import {ResourceError, throwIfError} from './ErrorHandling';
+
+export enum NotificationEventType {
+  repoPush = 'repo_push',
+  vulnFound = 'vulnerability_found',
+  buildFailure = 'build_failure',
+  buildQueued = 'build_queued',
+  buildStart = 'build_start',
+  buildSuccess = 'build_success',
+  buildCancelled = 'build_cancelled',
+  mirrorStarted = 'repo_mirror_sync_started',
+  mirrorSuccess = 'repo_mirror_sync_success',
+  mirrorFailed = 'repo_mirror_sync_failed',
+}
+
+export enum NotificationMethodType {
+  email = 'email',
+  flowdock = 'flowdock',
+  hipchat = 'hipchat',
+  quaynotification = 'quay_notification',
+  slack = 'slack',
+  webhook = 'webhook',
+}
+
+export interface RepoNotification {
+  config: any;
+  event: NotificationEventType;
+  event_config: any;
+  method: NotificationMethodType;
+  title: string;
+  number_of_failures?: number;
+  uuid?: string;
+}
+
+interface FetchNotifiationsResponse {
+  notifications: RepoNotification[];
+}
+
+export async function fetchNotifications(org: string, repo: string) {
+  const url = `/api/v1/repository/${org}/${repo}/notification/`;
+  const response: AxiosResponse<FetchNotifiationsResponse> = await axios.get(
+    url,
+  );
+  return response.data.notifications;
+}
+
+export async function createNotification(
+  org: string,
+  repo: string,
+  notification: RepoNotification,
+) {
+  // API requires camal case for this single field, modifying before sending
+  // rather than creating a new interface
+  const notificationRequest: any = notification;
+  notificationRequest.eventConfig = notificationRequest.event_config;
+  const url = `/api/v1/repository/${org}/${repo}/notification/`;
+  await axios.post(url, notificationRequest);
+}
+
+export async function bulkDeleteNotifications(
+  org: string,
+  repo: string,
+  uuids: string[],
+) {
+  const responses = await Promise.allSettled(
+    uuids.map((uuid) => deleteNotification(org, repo, uuid)),
+  );
+  throwIfError(responses);
+}
+
+export async function deleteNotification(
+  org: string,
+  repo: string,
+  uuid: string,
+) {
+  try {
+    const url = `/api/v1/repository/${org}/${repo}/notification/${uuid}`;
+    await axios.delete(url);
+  } catch (err) {
+    throw new ResourceError('failed to delete repository', uuid, err);
+  }
+}
+
+export async function testNotification(
+  org: string,
+  repo: string,
+  uuid: string,
+) {
+  const url = `/api/v1/repository/${org}/${repo}/notification/${uuid}/test`;
+  await axios.post(url);
+}
+
+export async function bulkEnableNotifications(
+  org: string,
+  repo: string,
+  uuids: string[],
+) {
+  const responses = await Promise.allSettled(
+    uuids.map((uuid) => enableNotification(org, repo, uuid)),
+  );
+  throwIfError(responses);
+}
+
+export async function enableNotification(
+  org: string,
+  repo: string,
+  uuid: string,
+) {
+  try {
+    const url = `/api/v1/repository/${org}/${repo}/notification/${uuid}`;
+    await axios.post(url);
+  } catch (err) {
+    throw new ResourceError('failed to enable repository', uuid, err);
+  }
+}
+
+// TODO: this should be a field from the backend instead of duplicating logic
+export function isNotificationDisabled(notification: RepoNotification) {
+  return notification.number_of_failures >= 3;
+}
+
+export function isNotificationEnabled(notification: RepoNotification) {
+  return !isNotificationDisabled(notification);
+}

--- a/src/resources/UserResource.ts
+++ b/src/resources/UserResource.ts
@@ -1,8 +1,8 @@
-import {AvatarProps} from '@patternfly/react-core';
 import {AxiosResponse} from 'axios';
 import axios from 'src/libs/axios';
 import {assertHttpCode} from './ErrorHandling';
 import {IAvatar, IOrganization} from './OrganizationResource';
+import {MemberType} from './RepositoryResource';
 
 export interface IUserResource {
   anonymous: boolean;
@@ -65,6 +65,16 @@ export interface Entity {
 
 interface EntitiesResponse {
   results: Entity[];
+}
+
+export function getMemberType(entity: Entity) {
+  if (entity.kind == MemberType.team) {
+    return MemberType.team;
+  } else if (entity.kind == MemberType.user && entity.is_robot) {
+    return MemberType.robot;
+  } else if (entity.kind == MemberType.user) {
+    return MemberType.user;
+  }
 }
 
 export async function fetchEntities(org: string, search: string) {

--- a/src/routes/RepositoryDetails/RepositoryDetails.tsx
+++ b/src/routes/RepositoryDetails/RepositoryDetails.tsx
@@ -29,7 +29,7 @@ import ErrorBoundary from 'src/components/errors/ErrorBoundary';
 import {addDisplayError, isErrorString} from 'src/resources/ErrorHandling';
 import RequestError from 'src/components/errors/RequestError';
 import {useQuayConfig} from 'src/hooks/UseQuayConfig';
-import Conditional from 'src/components/empty/Conditional';
+import CreateNotification from './Settings/NotificationsCreateNotification';
 
 enum TabIndex {
   Tags = 'tags',
@@ -81,6 +81,13 @@ export default function RepositoryDetails() {
     [DrawerContentType.None]: null,
     [DrawerContentType.AddPermission]: (
       <AddPermissions
+        org={organization}
+        repo={repository}
+        closeDrawer={closeDrawer}
+      />
+    ),
+    [DrawerContentType.CreateNotification]: (
+      <CreateNotification
         org={organization}
         repo={repository}
         closeDrawer={closeDrawer}
@@ -158,18 +165,20 @@ export default function RepositoryDetails() {
                       repoDetails={repoDetails}
                     />
                   </Tab>
-                  <Conditional if={config?.features.UI_V2_REPO_SETTINGS}>
-                    <Tab
-                      eventKey={TabIndex.Settings}
-                      title={<TabTitleText>Settings</TabTitleText>}
-                    >
-                      <Settings
-                        org={organization}
-                        repo={repository}
-                        setDrawerContent={setDrawerContent}
-                      />
-                    </Tab>
-                  </Conditional>
+                  <Tab
+                    eventKey={TabIndex.Settings}
+                    title={<TabTitleText>Settings</TabTitleText>}
+                    isHidden={
+                      config?.features.UI_V2_REPO_SETTINGS != true ||
+                      !repoDetails?.can_admin
+                    }
+                  >
+                    <Settings
+                      org={organization}
+                      repo={repository}
+                      setDrawerContent={setDrawerContent}
+                    />
+                  </Tab>
                 </Tabs>
               </ErrorBoundary>
             </PageSection>

--- a/src/routes/RepositoryDetails/Settings/ColumnNames.ts
+++ b/src/routes/RepositoryDetails/Settings/ColumnNames.ts
@@ -1,7 +1,12 @@
-const ColumnNames = {
-  account: 'Account',
-  type: 'Type',
-  permissions: 'Permissions',
-};
+export enum PermissionsColumnNames {
+  account = 'Account',
+  type = 'Type',
+  permissions = 'Permissions',
+}
 
-export default ColumnNames;
+export enum NotificationsColumnNames {
+  title = 'Title',
+  event = 'Event',
+  notification = 'Notification',
+  status = 'Status',
+}

--- a/src/routes/RepositoryDetails/Settings/Notifications.tsx
+++ b/src/routes/RepositoryDetails/Settings/Notifications.tsx
@@ -1,0 +1,196 @@
+import {Button, Flex, FlexItem, Spinner} from '@patternfly/react-core';
+import {BellIcon, BugIcon, UploadIcon} from '@patternfly/react-icons';
+import {
+  TableComposable,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
+import {useState} from 'react';
+import Empty from 'src/components/empty/Empty';
+import {useEvents} from 'src/hooks/UseEvents';
+import {useNotificationMethods} from 'src/hooks/UseNotificationMethods';
+import {useNotifications} from 'src/hooks/UseNotifications';
+import {
+  NotificationEventType,
+  NotificationMethodType,
+  RepoNotification,
+  isNotificationEnabled,
+} from 'src/resources/NotificationResource';
+import {DrawerContentType} from '../Types';
+import {NotificationsColumnNames} from './ColumnNames';
+import NotificationsKebab from './NotificationsKebab';
+import NotificationsToolbar from './NotificationsToolbar';
+
+export default function Notifications({
+  org,
+  repo,
+  ...props
+}: NotificationsProps) {
+  const [selectedNotifications, setSelectedNotifications] = useState<
+    RepoNotification[]
+  >([]);
+  const {
+    notifications,
+    loading,
+    error,
+    paginatedNotifications,
+    page,
+    setPage,
+    perPage,
+    setPerPage,
+    filter,
+    setFilter,
+    resetFilter,
+  } = useNotifications(org, repo);
+
+  const onSelectNotification = (
+    notification: RepoNotification,
+    rowIndex: number,
+    isSelecting: boolean,
+  ) => {
+    setSelectedNotifications((prevSelected) => {
+      const others = prevSelected.filter((r) => r.uuid !== notification.uuid);
+      return isSelecting ? [...others, notification] : others;
+    });
+  };
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (error) {
+    return <>Unable to load notifications</>;
+  }
+
+  if (notifications && notifications.length == 0) {
+    return (
+      <Empty
+        icon={BellIcon}
+        title="No notifications found"
+        body="No notifications have been setup for this repository"
+        button={
+          <Button
+            onClick={() =>
+              props.setDrawerContent(DrawerContentType.CreateNotification)
+            }
+          >
+            Create Notification
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <>
+      <NotificationsToolbar
+        org={org}
+        repo={repo}
+        allItems={notifications}
+        paginatedItems={paginatedNotifications}
+        selectedItems={selectedNotifications}
+        page={page}
+        setPage={setPage}
+        perPage={perPage}
+        setPerPage={setPerPage}
+        onItemSelect={onSelectNotification}
+        deselectAll={() => setSelectedNotifications([])}
+        setDrawerContent={props.setDrawerContent}
+        filter={filter}
+        setFilter={setFilter}
+        resetFilter={resetFilter}
+      />
+      <TableComposable aria-label="Repository notifications table">
+        <Thead>
+          <Tr>
+            <Th />
+            <Th>{NotificationsColumnNames.title}</Th>
+            <Th>{NotificationsColumnNames.event}</Th>
+            <Th>{NotificationsColumnNames.notification}</Th>
+            <Th>{NotificationsColumnNames.status}</Th>
+            <Th />
+          </Tr>
+        </Thead>
+        <Tbody>
+          {paginatedNotifications?.map((notification, rowIndex) => (
+            <Tr key={notification.uuid}>
+              <Td
+                select={{
+                  rowIndex,
+                  onSelect: (e, isSelecting) =>
+                    onSelectNotification(notification, rowIndex, isSelecting),
+                  isSelected: selectedNotifications.some(
+                    (n) => n.uuid === notification.uuid,
+                  ),
+                }}
+              />
+              <Td data-label="title">
+                {notification.title ? notification.title : '(Untitled)'}
+              </Td>
+              <Td data-label="event">
+                <EventTitle type={notification.event} />
+              </Td>
+              <Td data-label="notification">
+                <NotificationTitle notification={notification} />
+              </Td>
+              <Td data-label="status">
+                <NotificationStatus notification={notification} />
+              </Td>
+              <Td data-label="kebab">
+                <NotificationsKebab
+                  org={org}
+                  repo={repo}
+                  notification={notification}
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </TableComposable>
+    </>
+  );
+}
+
+function EventTitle({type}: {type: NotificationEventType}) {
+  const {events} = useEvents();
+  const event = events.find((e) => e.type == type);
+  // TODO: Icon returned from `events` needs to be added here
+  return <>{event.title}</>;
+}
+
+function NotificationTitle({notification}: {notification: RepoNotification}) {
+  const {notificationMethods} = useNotificationMethods();
+  const notificationMethod = notificationMethods.find(
+    (m) => m.type == notification.method,
+  );
+  if (notificationMethod.type == NotificationMethodType.email) {
+    return (
+      <Flex direction={{default: 'column'}}>
+        <FlexItem style={{marginBottom: 0}}>
+          {notificationMethod.title}
+        </FlexItem>
+        <FlexItem id="configured-email" style={{color: 'grey'}}>
+          email: {notification.config?.email}
+        </FlexItem>
+      </Flex>
+    );
+  }
+  return <>{notificationMethod.title}</>;
+}
+
+function NotificationStatus({notification}: {notification: RepoNotification}) {
+  return isNotificationEnabled(notification) ? (
+    <>Enabled</>
+  ) : (
+    <>Disabled due to 3 failed attempts in a row</>
+  );
+}
+
+interface NotificationsProps {
+  org: string;
+  repo: string;
+  setDrawerContent: (content: DrawerContentType) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsActions.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsActions.tsx
@@ -1,0 +1,118 @@
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertGroup,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import Conditional from 'src/components/empty/Conditional';
+import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
+import {
+  isNotificationDisabled,
+  RepoNotification,
+} from 'src/resources/NotificationResource';
+
+export default function Actions(props: ActionsProps) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const {
+    enableNotifications,
+    successEnablingNotification,
+    errorEnablingNotification,
+    resetEnablingNotification,
+    deleteNotifications,
+    errorDeletingNotification,
+    successDeletingNotification,
+    resetDeletingNotification,
+  } = useUpdateNotifications(props.org, props.repo);
+
+  useEffect(() => {
+    if (successEnablingNotification) {
+      props.deselectAll();
+      resetEnablingNotification();
+    }
+  }, [successEnablingNotification]);
+
+  useEffect(() => {
+    if (successDeletingNotification) {
+      props.deselectAll();
+      resetDeletingNotification();
+    }
+  }, [successDeletingNotification]);
+
+  const disabledNotifications: RepoNotification[] = props.selectedItems.filter(
+    (n) => isNotificationDisabled(n),
+  );
+  const notificationsToEnable: string[] = disabledNotifications.map(
+    (n) => n.uuid,
+  );
+
+  return (
+    <>
+      <Conditional if={errorDeletingNotification}>
+        <AlertGroup isToast isLiveRegion>
+          <Alert
+            variant="danger"
+            title="Unable to bulk delete notifications"
+            actionClose={
+              <AlertActionCloseButton onClose={resetDeletingNotification} />
+            }
+          />
+        </AlertGroup>
+      </Conditional>
+      <Conditional if={errorEnablingNotification}>
+        <AlertGroup isToast isLiveRegion>
+          <Alert
+            variant="danger"
+            title="Unable to bulk delete notifications"
+            actionClose={
+              <AlertActionCloseButton onClose={resetEnablingNotification} />
+            }
+          />
+        </AlertGroup>
+      </Conditional>
+      <Dropdown
+        onSelect={() => setIsOpen(false)}
+        toggle={
+          <DropdownToggle
+            isDisabled={props.isDisabled}
+            onToggle={(isOpen) => setIsOpen(isOpen)}
+          >
+            Actions
+          </DropdownToggle>
+        }
+        isOpen={isOpen}
+        dropdownItems={[
+          <Conditional
+            key="notifications-bulk-delete"
+            if={notificationsToEnable.length > 0}
+          >
+            <DropdownItem
+              onClick={() => enableNotifications(notificationsToEnable)}
+            >
+              Enable
+            </DropdownItem>
+          </Conditional>,
+          <DropdownItem
+            key="notifications-bulk-delete"
+            onClick={() => {
+              deleteNotifications(props.selectedItems.map((n) => n.uuid));
+            }}
+          >
+            Delete
+          </DropdownItem>,
+        ]}
+      />
+    </>
+  );
+}
+
+interface ActionsProps {
+  isDisabled?: boolean;
+  org: string;
+  repo: string;
+  selectedItems: RepoNotification[];
+  deselectAll: () => void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsCreateNotification.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsCreateNotification.tsx
@@ -1,0 +1,156 @@
+import {
+  Alert,
+  AlertActionCloseButton,
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  Form,
+  FormGroup,
+  Title,
+} from '@patternfly/react-core';
+import {useState} from 'react';
+import Conditional from 'src/components/empty/Conditional';
+import {NotificationEvent, useEvents} from 'src/hooks/UseEvents';
+import {
+  NotificationMethod,
+  useNotificationMethods,
+} from 'src/hooks/UseNotificationMethods';
+import {NotificationMethodType} from 'src/resources/NotificationResource';
+import CreateEmailNotification from './NotificationsCreateNotificationEmail';
+import CreateFlowdockNotification from './NotificationsCreateNotificationFlowdock';
+import CreateHipchatNotification from './NotificationsCreateNotificationHipchat';
+import CreateQuayNotification from './NotificationsCreateNotificationQuay';
+import CreateSlackNotification from './NotificationsCreateNotificationSlack';
+import CreateWebhookNotification from './NotificationsCreateNotificationWebhook';
+
+export default function CreateNotification(props: CreateNotificationProps) {
+  const [isEventOpen, setIsEventOpen] = useState<boolean>();
+  const [isMethodOpen, setIsMethodOpen] = useState<boolean>();
+  const [event, setEvent] = useState<NotificationEvent>();
+  const [method, setMethod] = useState<NotificationMethod>();
+  const {events} = useEvents();
+  const {notificationMethods} = useNotificationMethods();
+  const [error, setError] = useState<string>('');
+
+  return (
+    <>
+      <Title headingLevel="h3">Create Notification</Title>
+      <Form id="create-notification-form">
+        <Conditional if={error != ''}>
+          <Alert
+            isInline
+            actionClose={
+              <AlertActionCloseButton onClose={() => setError('')} />
+            }
+            variant="danger"
+            title={error}
+          />
+        </Conditional>
+        <FormGroup fieldId="event" label="When this event occurs" required>
+          <Dropdown
+            onSelect={() => setIsEventOpen(false)}
+            toggle={
+              <DropdownToggle onToggle={(isOpen) => setIsEventOpen(isOpen)}>
+                {event?.title ? event?.title : 'Select event...'}
+              </DropdownToggle>
+            }
+            isOpen={isEventOpen}
+            dropdownItems={events.map((event) => (
+              <Conditional key={event.type} if={event.enabled}>
+                <DropdownItem onClick={() => setEvent(event)}>
+                  {event.icon} {event.title}
+                </DropdownItem>
+              </Conditional>
+            ))}
+          />
+        </FormGroup>
+        <FormGroup fieldId="method" label="Then issue a notification" required>
+          <Dropdown
+            onSelect={() => setIsMethodOpen(false)}
+            toggle={
+              <DropdownToggle onToggle={(isOpen) => setIsMethodOpen(isOpen)}>
+                {method?.title ? method?.title : 'Select method...'}
+              </DropdownToggle>
+            }
+            isOpen={isMethodOpen}
+            dropdownItems={notificationMethods.map((method) => (
+              <Conditional key={method.type} if={method.enabled}>
+                <DropdownItem onClick={() => setMethod(method)}>
+                  {method.title}
+                </DropdownItem>
+              </Conditional>
+            ))}
+          />
+        </FormGroup>
+        <Conditional if={method?.type == NotificationMethodType.email}>
+          <CreateEmailNotification
+            org={props.org}
+            repo={props.repo}
+            event={event}
+            method={method}
+            closeDrawer={props.closeDrawer}
+            setError={setError}
+          />
+        </Conditional>
+        <Conditional
+          if={method?.type == NotificationMethodType.quaynotification}
+        >
+          <CreateQuayNotification
+            org={props.org}
+            repo={props.repo}
+            event={event}
+            method={method}
+            closeDrawer={props.closeDrawer}
+            setError={setError}
+          />
+        </Conditional>
+        <Conditional if={method?.type == NotificationMethodType.flowdock}>
+          <CreateFlowdockNotification
+            org={props.org}
+            repo={props.repo}
+            event={event}
+            method={method}
+            closeDrawer={props.closeDrawer}
+            setError={setError}
+          />
+        </Conditional>
+        <Conditional if={method?.type == NotificationMethodType.hipchat}>
+          <CreateHipchatNotification
+            org={props.org}
+            repo={props.repo}
+            event={event}
+            method={method}
+            closeDrawer={props.closeDrawer}
+            setError={setError}
+          />
+        </Conditional>
+        <Conditional if={method?.type == NotificationMethodType.slack}>
+          <CreateSlackNotification
+            org={props.org}
+            repo={props.repo}
+            event={event}
+            method={method}
+            closeDrawer={props.closeDrawer}
+            setError={setError}
+          />
+        </Conditional>
+        <Conditional if={method?.type == NotificationMethodType.webhook}>
+          <CreateWebhookNotification
+            org={props.org}
+            repo={props.repo}
+            event={event}
+            method={method}
+            closeDrawer={props.closeDrawer}
+            setError={setError}
+          />
+        </Conditional>
+      </Form>
+    </>
+  );
+}
+
+interface CreateNotificationProps {
+  org: string;
+  repo: string;
+  closeDrawer: () => void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationEmail.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationEmail.tsx
@@ -1,0 +1,215 @@
+import {
+  ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import Conditional from 'src/components/empty/Conditional';
+import {useAuthorizedEmails} from 'src/hooks/UseAuthorizedEmails';
+import {NotificationEvent} from 'src/hooks/UseEvents';
+import {NotificationMethod} from 'src/hooks/UseNotificationMethods';
+import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
+import {isValidEmail} from 'src/libs/utils';
+import {fetchAuthorizedEmail} from 'src/resources/AuthorizedEmailResource';
+
+export default function CreateEmailNotification(
+  props: CreateEmailNotification,
+) {
+  const [title, setTitle] = useState<string>('');
+  const [email, setEmail] = useState<string>('');
+  const [isEmailAuthModalOpen, setIsEmailAuthModalOpen] = useState<boolean>();
+  const {
+    create,
+    successCreatingNotification,
+    errorCreatingNotification,
+    resetCreatingNotification,
+  } = useUpdateNotifications(props.org, props.repo);
+  const {
+    emailConfirmed,
+    resetEmailConfirmed,
+    polling,
+    startPolling,
+    stopPolling,
+    errorPolling,
+    sendAuthorizedEmail,
+    successSendingAuthorizedEmail,
+    errorSendingAuthorizedEmail,
+    resetSendAuthorizationEmail,
+  } = useAuthorizedEmails(props.org, props.repo);
+
+  const isFormComplete =
+    props.method != undefined &&
+    props.event != undefined &&
+    email != undefined &&
+    email != '' &&
+    isValidEmail(email);
+
+  useEffect(() => {
+    if (successSendingAuthorizedEmail) {
+      startPolling(email);
+      resetSendAuthorizationEmail();
+      setIsEmailAuthModalOpen(false);
+    }
+  }, [successSendingAuthorizedEmail]);
+
+  useEffect(() => {
+    if (emailConfirmed) {
+      create({
+        config: {
+          email: email,
+        },
+        event: props.event?.type,
+        event_config: {},
+        method: props.method?.type,
+        title: title,
+      });
+      resetEmailConfirmed();
+    }
+  }, [emailConfirmed]);
+
+  useEffect(() => {
+    if (successCreatingNotification) {
+      resetCreatingNotification();
+      props.closeDrawer();
+    }
+  }, [successCreatingNotification]);
+
+  useEffect(() => {
+    if (errorCreatingNotification) {
+      props.setError('Unable to create notification');
+      resetCreatingNotification();
+    }
+  }, [errorCreatingNotification]);
+
+  const createNotification = async () => {
+    let emailStatus = null;
+    try {
+      emailStatus = await fetchAuthorizedEmail(props.org, props.repo, email);
+    } catch (err) {
+      props.setError('Unable to verify email');
+    }
+    if (emailStatus != null && emailStatus.confirmed) {
+      create({
+        config: {
+          email: email,
+        },
+        event: props.event?.type,
+        event_config: {},
+        method: props.method?.type,
+        title: title,
+      });
+    } else {
+      setIsEmailAuthModalOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <Modal
+        variant={ModalVariant.small}
+        title="Email Authorization"
+        isOpen={isEmailAuthModalOpen}
+        onClose={() => setIsEmailAuthModalOpen(false)}
+        actions={[
+          <Button
+            key="sendemail"
+            variant="primary"
+            onClick={() => sendAuthorizedEmail(email)}
+          >
+            Send Authorized Email
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={() => setIsEmailAuthModalOpen(false)}
+          >
+            Cancel
+          </Button>,
+        ]}
+      >
+        <Conditional if={errorSendingAuthorizedEmail}>
+          <Alert
+            isInline
+            actionClose={
+              <AlertActionCloseButton onClose={resetSendAuthorizationEmail} />
+            }
+            variant="danger"
+            title="Failure sending authorized email"
+          />
+        </Conditional>
+        The email address {email} has not been authorized to recieve
+        notifications from this repository. Please click &lsquo;Send Authorized
+        Email&lsquo; to start the authorization process.
+      </Modal>
+      <Modal
+        variant={ModalVariant.small}
+        title="Email Authorization"
+        isOpen={polling}
+        onClose={stopPolling}
+        actions={[
+          <Button key="cancel" variant="primary" onClick={stopPolling}>
+            Cancel
+          </Button>,
+        ]}
+      >
+        An email has been sent to {email}. Please click the link contained in
+        the email.
+      </Modal>
+      <Modal
+        variant={ModalVariant.small}
+        title="Email Authorization"
+        isOpen={errorPolling}
+        actions={[
+          <Button
+            key="cancel"
+            variant="primary"
+            onClick={() => startPolling(email)}
+          >
+            Retry
+          </Button>,
+        ]}
+      >
+        Unable to verify email confirmation. Please wait a moment and retry.
+      </Modal>
+      <FormGroup fieldId="email" label="E-mail address" required>
+        <TextInput
+          id="notification-email"
+          isRequired
+          value={email}
+          onChange={(value) => setEmail(value)}
+          validated={email == '' || isValidEmail(email) ? 'default' : 'error'}
+        />
+      </FormGroup>
+      <FormGroup fieldId="title" label="Title">
+        <TextInput
+          id="notification-title"
+          value={title}
+          onChange={(value) => setTitle(value)}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button
+          isDisabled={!isFormComplete}
+          onClick={createNotification}
+          variant="primary"
+        >
+          Submit
+        </Button>
+      </ActionGroup>
+    </>
+  );
+}
+
+interface CreateEmailNotification {
+  org: string;
+  repo: string;
+  event: NotificationEvent;
+  method: NotificationMethod;
+  closeDrawer: () => void;
+  setError: (error: string) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationFlowdock.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationFlowdock.tsx
@@ -1,0 +1,91 @@
+import {NotificationEvent} from 'src/hooks/UseEvents';
+import {NotificationMethod} from 'src/hooks/UseNotificationMethods';
+import {
+  ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
+
+export default function CreateFlowdockNotification(
+  props: CreateFlowdockNotification,
+) {
+  const [title, setTitle] = useState<string>('');
+  const [apiTopken, setAPIToken] = useState<string>('');
+  const {
+    create,
+    successCreatingNotification,
+    errorCreatingNotification,
+    resetCreatingNotification,
+  } = useUpdateNotifications(props.org, props.repo);
+
+  const isFormComplete =
+    props.method != undefined && props.event != undefined && apiTopken != '';
+
+  const createNotification = async () => {
+    create({
+      config: {
+        flow_api_token: apiTopken,
+      },
+      event: props.event?.type,
+      event_config: {},
+      method: props.method?.type,
+      title: title,
+    });
+  };
+
+  useEffect(() => {
+    if (successCreatingNotification) {
+      resetCreatingNotification();
+      props.closeDrawer();
+    }
+  }, [successCreatingNotification]);
+
+  return (
+    <>
+      <FormGroup
+        fieldId="flowdock-api-token"
+        label="Flowdock API token"
+        required
+      >
+        <TextInput
+          required
+          id="flowdock-api-token-field"
+          value={apiTopken}
+          onChange={(value) => setAPIToken(value)}
+        />
+      </FormGroup>
+      <FormGroup fieldId="title" label="Title">
+        <TextInput
+          id="notification-title"
+          value={title}
+          onChange={(value) => setTitle(value)}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button
+          isDisabled={!isFormComplete}
+          onClick={createNotification}
+          variant="primary"
+        >
+          Submit
+        </Button>
+      </ActionGroup>
+    </>
+  );
+}
+
+interface CreateFlowdockNotification {
+  org: string;
+  repo: string;
+  event: NotificationEvent;
+  method: NotificationMethod;
+  closeDrawer: () => void;
+  setError: (error: string) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationHipchat.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationHipchat.tsx
@@ -1,0 +1,104 @@
+import {NotificationEvent} from 'src/hooks/UseEvents';
+import {NotificationMethod} from 'src/hooks/UseNotificationMethods';
+import {
+  ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
+
+export default function CreateHipchatNotification(
+  props: CreateHipchatNotification,
+) {
+  const [roomId, setRoomId] = useState<string>('');
+  const [token, setToken] = useState<string>('');
+  const [title, setTitle] = useState<string>('');
+  const {
+    create,
+    successCreatingNotification,
+    errorCreatingNotification,
+    resetCreatingNotification,
+  } = useUpdateNotifications(props.org, props.repo);
+
+  const isFormComplete =
+    props.method != undefined &&
+    props.event != undefined &&
+    token != '' &&
+    roomId != '';
+
+  const createNotification = async () => {
+    create({
+      config: {
+        notification_token: token,
+        room_id: roomId,
+      },
+      event: props.event?.type,
+      event_config: {},
+      method: props.method?.type,
+      title: title,
+    });
+  };
+
+  useEffect(() => {
+    if (successCreatingNotification) {
+      resetCreatingNotification();
+      props.closeDrawer();
+    }
+  }, [successCreatingNotification]);
+
+  return (
+    <>
+      <FormGroup fieldId="room-id-number" label="Room ID #" required>
+        <TextInput
+          required
+          id="room-id-number-field"
+          value={roomId}
+          onChange={(value) => setRoomId(value)}
+        />
+      </FormGroup>
+      <FormGroup
+        fieldId="room-notification-token"
+        label="Room Notification Token"
+        required
+      >
+        <TextInput
+          required
+          id="room-notification-token-field"
+          value={token}
+          onChange={(value) => setToken(value)}
+        />
+      </FormGroup>
+      <FormGroup fieldId="title" label="Title">
+        <TextInput
+          id="notification-title"
+          value={title}
+          onChange={(value) => setTitle(value)}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button
+          isDisabled={!isFormComplete}
+          onClick={createNotification}
+          variant="primary"
+        >
+          Submit
+        </Button>
+      </ActionGroup>
+    </>
+  );
+}
+
+interface CreateHipchatNotification {
+  org: string;
+  repo: string;
+  event: NotificationEvent;
+  method: NotificationMethod;
+  closeDrawer: () => void;
+  setError: (error: string) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationQuay.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationQuay.tsx
@@ -1,0 +1,88 @@
+import {NotificationEvent} from 'src/hooks/UseEvents';
+import {NotificationMethod} from 'src/hooks/UseNotificationMethods';
+import {
+  ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import EntitySearch from 'src/components/EntitySearch';
+import {Entity} from 'src/resources/UserResource';
+import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
+
+export default function CreateQuayNotification(props: CreateQuayNotification) {
+  const [title, setTitle] = useState<string>('');
+  const [selectedEntity, setSelectedEntity] = useState<Entity>(null);
+  const {
+    create,
+    successCreatingNotification,
+    errorCreatingNotification,
+    resetCreatingNotification,
+  } = useUpdateNotifications(props.org, props.repo);
+
+  const isFormComplete =
+    props.method != undefined &&
+    props.event != undefined &&
+    selectedEntity != null;
+
+  const createNotification = async () => {
+    create({
+      config: {
+        target: selectedEntity,
+      },
+      event: props.event?.type,
+      event_config: {},
+      method: props.method?.type,
+      title: title,
+    });
+  };
+
+  useEffect(() => {
+    if (successCreatingNotification) {
+      resetCreatingNotification();
+      props.closeDrawer();
+    }
+  }, [successCreatingNotification]);
+
+  return (
+    <>
+      <FormGroup fieldId="quayNotificationRecipient" label="Recipient" required>
+        <EntitySearch
+          org={props.org}
+          onSelect={(e: Entity) => setSelectedEntity(e)}
+          onError={() => props.setError('Unable to look up users')}
+        />
+      </FormGroup>
+      <FormGroup fieldId="title" label="Title">
+        <TextInput
+          id="notification-title"
+          value={title}
+          onChange={(value) => setTitle(value)}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button
+          isDisabled={!isFormComplete}
+          onClick={createNotification}
+          variant="primary"
+        >
+          Submit
+        </Button>
+      </ActionGroup>
+    </>
+  );
+}
+
+interface CreateQuayNotification {
+  org: string;
+  repo: string;
+  event: NotificationEvent;
+  method: NotificationMethod;
+  closeDrawer: () => void;
+  setError: (error: string) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationSlack.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationSlack.tsx
@@ -1,0 +1,87 @@
+import {NotificationEvent} from 'src/hooks/UseEvents';
+import {NotificationMethod} from 'src/hooks/UseNotificationMethods';
+import {
+  ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextInput,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
+
+export default function CreateSlackNotification(
+  props: CreateSlackNotificationProps,
+) {
+  const [url, setUrl] = useState<string>('');
+  const [title, setTitle] = useState<string>('');
+  const {
+    create,
+    successCreatingNotification,
+    errorCreatingNotification,
+    resetCreatingNotification,
+  } = useUpdateNotifications(props.org, props.repo);
+
+  const isFormComplete =
+    props.method != undefined && props.event != undefined && url != '';
+
+  const createNotification = async () => {
+    create({
+      config: {
+        url: url,
+      },
+      event: props.event?.type,
+      event_config: {},
+      method: props.method?.type,
+      title: title,
+    });
+  };
+
+  useEffect(() => {
+    if (successCreatingNotification) {
+      resetCreatingNotification();
+      props.closeDrawer();
+    }
+  }, [successCreatingNotification]);
+
+  return (
+    <>
+      <FormGroup fieldId="slack-webhook-url" label="Webhook URL" required>
+        <TextInput
+          required
+          id="slack-webhook-url-field"
+          value={url}
+          onChange={(value) => setUrl(value)}
+        />
+      </FormGroup>
+      <FormGroup fieldId="title" label="Title">
+        <TextInput
+          id="notification-title"
+          value={title}
+          onChange={(value) => setTitle(value)}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button
+          isDisabled={!isFormComplete}
+          onClick={createNotification}
+          variant="primary"
+        >
+          Submit
+        </Button>
+      </ActionGroup>
+    </>
+  );
+}
+
+interface CreateSlackNotificationProps {
+  org: string;
+  repo: string;
+  event: NotificationEvent;
+  method: NotificationMethod;
+  closeDrawer: () => void;
+  setError: (error: string) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationWebhook.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsCreateNotificationWebhook.tsx
@@ -1,0 +1,98 @@
+import {NotificationEvent} from 'src/hooks/UseEvents';
+import {NotificationMethod} from 'src/hooks/UseNotificationMethods';
+import {
+  ActionGroup,
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  FormGroup,
+  Modal,
+  ModalVariant,
+  TextArea,
+  TextInput,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
+
+export default function CreateWebhookNotification(
+  props: CreateWebhookNotificationProps,
+) {
+  const [url, setUrl] = useState<string>('');
+  const [jsonBody, setJsonBody] = useState<string>('');
+  const [title, setTitle] = useState<string>('');
+  const {
+    create,
+    successCreatingNotification,
+    errorCreatingNotification,
+    resetCreatingNotification,
+  } = useUpdateNotifications(props.org, props.repo);
+
+  const isFormComplete =
+    props.method != undefined && props.event != undefined && url != '';
+
+  const createNotification = async () => {
+    create({
+      config: {
+        url: url,
+        template: jsonBody,
+      },
+      event: props.event?.type,
+      event_config: {},
+      method: props.method?.type,
+      title: title,
+    });
+  };
+
+  useEffect(() => {
+    if (successCreatingNotification) {
+      resetCreatingNotification();
+      props.closeDrawer();
+    }
+  }, [successCreatingNotification]);
+
+  return (
+    <>
+      <FormGroup fieldId="webhook-url" label="Webhook URL" required>
+        <TextInput
+          required
+          id="webhook-url-field"
+          value={url}
+          onChange={(value) => setUrl(value)}
+        />
+      </FormGroup>
+      <FormGroup fieldId="webhook-body" label="POST body template " required>
+        <TextArea
+          id="json-body-field"
+          value={jsonBody}
+          onChange={(value) => setJsonBody(value)}
+          isRequired
+        />
+      </FormGroup>
+      <FormGroup fieldId="title" label="Title">
+        <TextInput
+          id="notification-title"
+          value={title}
+          onChange={(value) => setTitle(value)}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button
+          isDisabled={!isFormComplete}
+          onClick={createNotification}
+          variant="primary"
+        >
+          Submit
+        </Button>
+      </ActionGroup>
+    </>
+  );
+}
+
+interface CreateWebhookNotificationProps {
+  org: string;
+  repo: string;
+  event: NotificationEvent;
+  method: NotificationMethod;
+  closeDrawer: () => void;
+  setError: (error: string) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsFilter.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsFilter.tsx
@@ -1,0 +1,125 @@
+import {
+  MenuContent,
+  MenuItem,
+  Menu as PFMenu,
+  MenuList,
+  Checkbox,
+} from '@patternfly/react-core';
+import {useState} from 'react';
+import Menu from 'src/components/Table/Menu';
+import {useEvents} from 'src/hooks/UseEvents';
+import {
+  NotifiationStatus,
+  NotificationFilter,
+} from 'src/hooks/UseNotifications';
+import {NotificationEventType} from 'src/resources/NotificationResource';
+
+export default function NotificationsFilter(props: NotificationsFilterProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
+  const {events} = useEvents();
+
+  const selectEvent = (checked: boolean, event: NotificationEventType) => {
+    props.setFilter((prev) => {
+      const others = prev.event.filter((f) => f !== event);
+      prev.event = checked ? [...others, event] : others;
+      return {...prev, event: prev.event};
+    });
+  };
+
+  const selectStatus = (checked: boolean, status: NotifiationStatus) => {
+    props.setFilter((prev) => {
+      const others = prev.status.filter((f) => f !== status);
+      prev.status = checked ? [...others, status] : others;
+      return {...prev, status: prev.status};
+    });
+  };
+
+  return (
+    <Menu
+      toggle="Filter"
+      isOpen={isMenuOpen}
+      setIsOpen={setIsMenuOpen}
+      items={[
+        <MenuItem
+          id="filter-events"
+          key="filter-events"
+          flyoutMenu={
+            <PFMenu key={1}>
+              <MenuContent>
+                <MenuList>
+                  {events.map((e) => (
+                    <MenuItem key={e.type} style={{width: 'max-content'}}>
+                      <Checkbox
+                        id={`${e.title}-checkbox`}
+                        label={e.title}
+                        isChecked={props.filter.event.includes(e.type)}
+                        onChange={(checked: boolean) => {
+                          selectEvent(checked, e.type);
+                        }}
+                        name={`${e.title}-checkbox`}
+                      />
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </MenuContent>
+            </PFMenu>
+          }
+        >
+          Events
+        </MenuItem>,
+        <MenuItem
+          id="filter-status"
+          key="filter-events"
+          flyoutMenu={
+            <PFMenu key={0}>
+              <MenuContent>
+                <MenuList>
+                  <MenuItem
+                    key="filter-status-enabled"
+                    style={{width: 'max-content'}}
+                  >
+                    <Checkbox
+                      id="enabled-checkbox"
+                      label="Enabled"
+                      isChecked={props.filter.status.includes(
+                        NotifiationStatus.enabled,
+                      )}
+                      onChange={(checked: boolean) => {
+                        selectStatus(checked, NotifiationStatus.enabled);
+                      }}
+                      name="enabled-checkbox"
+                    />
+                  </MenuItem>
+                  <MenuItem
+                    key="filter-status-disabled"
+                    style={{width: 'max-content'}}
+                  >
+                    <Checkbox
+                      id="disabled-checkbox"
+                      label="Disabled"
+                      isChecked={props.filter.status.includes(
+                        NotifiationStatus.disabled,
+                      )}
+                      onChange={(checked: boolean) => {
+                        selectStatus(checked, NotifiationStatus.disabled);
+                      }}
+                      name="disabled-checkbox"
+                    />
+                  </MenuItem>
+                </MenuList>
+              </MenuContent>
+            </PFMenu>
+          }
+          itemId="next-menu-root"
+        >
+          Status
+        </MenuItem>,
+      ]}
+    />
+  );
+}
+
+interface NotificationsFilterProps {
+  filter: NotificationFilter;
+  setFilter(set: (prev: NotificationFilter) => NotificationFilter): void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsFilterChips.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsFilterChips.tsx
@@ -1,0 +1,43 @@
+import {Toolbar, ToolbarFilter} from '@patternfly/react-core';
+import {NotificationFilter} from 'src/hooks/UseNotifications';
+
+export default function NotificationsFilterChips(
+  props: NotificationsFilterChipsProps,
+) {
+  const deleteFilter = (category: string, chip: string) => {
+    props.setFilter((prev) => {
+      const others = prev[category].filter((e) => e != chip);
+      return {
+        ...prev,
+        [category]: others,
+      };
+    });
+  };
+
+  return (
+    <>
+      <ToolbarFilter
+        chips={props.filter.event}
+        deleteChip={(category, chip) => deleteFilter('event', chip as string)}
+        deleteChipGroup={() => props.resetFilter('event')}
+        categoryName="Event"
+      >
+        {}
+      </ToolbarFilter>
+      <ToolbarFilter
+        chips={props.filter.status}
+        deleteChip={(category, chip) => deleteFilter('status', chip as string)}
+        deleteChipGroup={() => props.resetFilter('status')}
+        categoryName="Status"
+      >
+        {}
+      </ToolbarFilter>
+    </>
+  );
+}
+
+interface NotificationsFilterChipsProps {
+  filter: NotificationFilter;
+  setFilter(set: (prev: NotificationFilter) => NotificationFilter): void;
+  resetFilter(field?: string): void;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsKebab.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsKebab.tsx
@@ -1,0 +1,138 @@
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertGroup,
+  Button,
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+  Modal,
+  ModalVariant,
+} from '@patternfly/react-core';
+import {useEffect, useState} from 'react';
+import {useUpdateNotifications} from 'src/hooks/UseUpdateNotifications';
+import Conditional from 'src/components/empty/Conditional';
+import {
+  isNotificationDisabled,
+  RepoNotification,
+} from 'src/resources/NotificationResource';
+
+export default function NotificationsKebab({
+  org,
+  repo,
+  notification,
+}: NotificationsKebabProps) {
+  const [isOpen, setIsOpen] = useState<boolean>();
+  const [isTestModalOpen, setIsTestModalOpen] = useState<boolean>(false);
+  const {
+    deleteNotifications,
+    errorDeletingNotification,
+    resetDeletingNotification,
+    test,
+    successTestingNotification,
+    errorTestingNotification,
+    resetTestingNotification,
+    enableNotifications,
+    errorEnablingNotification,
+    resetEnablingNotification,
+  } = useUpdateNotifications(org, repo);
+
+  useEffect(() => {
+    if (successTestingNotification) {
+      setIsTestModalOpen(true);
+      resetTestingNotification();
+    }
+  }, [successTestingNotification]);
+
+  return (
+    <>
+      <Conditional if={errorDeletingNotification}>
+        <AlertGroup isToast isLiveRegion>
+          <Alert
+            variant="danger"
+            title={`Unable to delete notification ${notification.title}`}
+            actionClose={
+              <AlertActionCloseButton onClose={resetDeletingNotification} />
+            }
+          />
+        </AlertGroup>
+      </Conditional>
+      <Conditional if={errorTestingNotification}>
+        <AlertGroup isToast isLiveRegion>
+          <Alert
+            variant="danger"
+            title={`Unable to test notification ${notification.title}`}
+            actionClose={
+              <AlertActionCloseButton onClose={resetTestingNotification} />
+            }
+          />
+        </AlertGroup>
+      </Conditional>
+      <Conditional if={errorEnablingNotification}>
+        <AlertGroup isToast isLiveRegion>
+          <Alert
+            variant="danger"
+            title={`Unable to enable notification ${notification.title}`}
+            actionClose={
+              <AlertActionCloseButton onClose={resetEnablingNotification} />
+            }
+          />
+        </AlertGroup>
+      </Conditional>
+      <Modal
+        variant={ModalVariant.small}
+        title="Test Notification Queued"
+        isOpen={isTestModalOpen}
+        onClose={() => setIsTestModalOpen(false)}
+        actions={[
+          <Button
+            key="cancel"
+            variant="primary"
+            onClick={() => setIsTestModalOpen(false)}
+          >
+            Close
+          </Button>,
+        ]}
+      >
+        A test version of this notification has been queued and should appear
+        shortly
+      </Modal>
+      <Dropdown
+        onSelect={() => setIsOpen(false)}
+        toggle={
+          <KebabToggle
+            onToggle={() => {
+              setIsOpen(!isOpen);
+            }}
+          />
+        }
+        isOpen={isOpen}
+        dropdownItems={[
+          <DropdownItem key="test" onClick={() => test(notification.uuid)}>
+            Test Notification
+          </DropdownItem>,
+          <DropdownItem
+            key="delete"
+            onClick={() => deleteNotifications(notification.uuid)}
+          >
+            Delete Notification
+          </DropdownItem>,
+          <Conditional key="enable" if={isNotificationDisabled(notification)}>
+            <DropdownItem
+              onClick={() => enableNotifications(notification.uuid)}
+            >
+              Enable Notification
+            </DropdownItem>
+          </Conditional>,
+        ]}
+        isPlain
+      />
+    </>
+  );
+}
+
+interface NotificationsKebabProps {
+  org: string;
+  repo: string;
+  notification: RepoNotification;
+}

--- a/src/routes/RepositoryDetails/Settings/NotificationsToolbar.tsx
+++ b/src/routes/RepositoryDetails/Settings/NotificationsToolbar.tsx
@@ -1,0 +1,98 @@
+import {
+  Button,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import {DropdownCheckbox} from 'src/components/toolbar/DropdownCheckbox';
+import {ToolbarPagination} from 'src/components/toolbar/ToolbarPagination';
+import {DrawerContentType} from '../Types';
+import {RepoNotification} from 'src/resources/NotificationResource';
+import NotificationsFilter from './NotificationsFilter';
+import {NotificationFilter} from 'src/hooks/UseNotifications';
+import NotificationsFilterChips from './NotificationsFilterChips';
+import Actions from './NotificationsActions';
+
+export default function NotificationsToolbar(props: NotificationsToolbarProps) {
+  return (
+    <Toolbar clearAllFilters={() => props.resetFilter()}>
+      <ToolbarContent>
+        <DropdownCheckbox
+          id="notifications-select-all"
+          selectedItems={props.selectedItems}
+          deSelectAll={props.deselectAll}
+          allItemsList={props.allItems}
+          itemsPerPageList={props.paginatedItems}
+          onItemSelect={props.onItemSelect}
+        />
+        <ToolbarItem>
+          <NotificationsFilter
+            filter={props.filter}
+            setFilter={props.setFilter}
+          />
+        </ToolbarItem>
+        <ToolbarGroup variant="filter-group">
+          <NotificationsFilterChips
+            filter={props.filter}
+            setFilter={props.setFilter}
+            resetFilter={props.resetFilter}
+          />
+        </ToolbarGroup>
+        <ToolbarItem>
+          <Button
+            onClick={() =>
+              props.setDrawerContent(DrawerContentType.CreateNotification)
+            }
+          >
+            Create Notification
+          </Button>
+        </ToolbarItem>
+        <ToolbarItem>
+          <Actions
+            isDisabled={props.selectedItems.length == 0}
+            org={props.org}
+            repo={props.repo}
+            selectedItems={props.selectedItems}
+            deselectAll={props.deselectAll}
+          />
+        </ToolbarItem>
+        <ToolbarPagination
+          itemsList={props.allItems}
+          perPage={props.perPage}
+          page={props.page}
+          setPage={props.setPage}
+          setPerPage={props.setPerPage}
+        />
+      </ToolbarContent>
+    </Toolbar>
+  );
+}
+
+interface NotificationsToolbarProps {
+  org: string;
+  repo: string;
+
+  allItems: RepoNotification[];
+  paginatedItems: RepoNotification[];
+  selectedItems: RepoNotification[];
+
+  page: number;
+  setPage: (page: number) => void;
+  perPage: number;
+  setPerPage: (perPage: number) => void;
+
+  filter: NotificationFilter;
+  setFilter(
+    set: (prev: NotificationFilter) => NotificationFilter | NotificationFilter,
+  ): void;
+  resetFilter(field?: string): void;
+
+  onItemSelect: (
+    item: RepoNotification,
+    rowIndex: number,
+    isSelecting: boolean,
+  ) => void;
+  deselectAll: () => void;
+  setDrawerContent: (content: DrawerContentType) => void;
+}

--- a/src/routes/RepositoryDetails/Settings/Permissions.tsx
+++ b/src/routes/RepositoryDetails/Settings/Permissions.tsx
@@ -10,7 +10,7 @@ import {
 import {useState} from 'react';
 import {useRepositoryPermissions} from 'src/hooks/UseRepositoryPermissions';
 import PermissionsToolbar from './PermissionsToolbar';
-import ColumnNames from './ColumnNames';
+import {PermissionsColumnNames} from './ColumnNames';
 import PermissionsDropdown from './PermissionsDropdown';
 import {RepoMember} from 'src/resources/RepositoryResource';
 import PermissionsKebab from './PermissionsKebab';
@@ -62,7 +62,7 @@ export default function Permissions(props: PermissionsProps) {
         setPage={setPage}
         perPage={perPage}
         setPerPage={setPerPage}
-        searchOptions={[ColumnNames.account]}
+        searchOptions={[PermissionsColumnNames.account]}
         search={search}
         setSearch={setSearch}
         onItemSelect={onSelectMember}
@@ -73,9 +73,9 @@ export default function Permissions(props: PermissionsProps) {
         <Thead>
           <Tr>
             <Th />
-            <Th>{ColumnNames.account}</Th>
-            <Th>{ColumnNames.type}</Th>
-            <Th>{ColumnNames.permissions}</Th>
+            <Th>{PermissionsColumnNames.account}</Th>
+            <Th>{PermissionsColumnNames.type}</Th>
+            <Th>{PermissionsColumnNames.permissions}</Th>
             <Th />
           </Tr>
         </Thead>

--- a/src/routes/RepositoryDetails/Settings/PermissionsAddPermission.tsx
+++ b/src/routes/RepositoryDetails/Settings/PermissionsAddPermission.tsx
@@ -2,61 +2,34 @@ import {
   ActionGroup,
   Alert,
   AlertActionCloseButton,
-  AlertGroup,
   Button,
   Dropdown,
   DropdownItem,
   DropdownToggle,
   Form,
   FormGroup,
-  Select,
-  SelectOption,
-  SelectVariant,
   Title,
 } from '@patternfly/react-core';
 import {useEffect, useState} from 'react';
 import Conditional from 'src/components/empty/Conditional';
-import {useEntities} from 'src/hooks/UseEntities';
+import EntitySearch from 'src/components/EntitySearch';
 import {useUpdateRepositoryPermissions} from 'src/hooks/UseUpdateRepositoryPermissions';
-import {
-  RepoMember,
-  MemberType,
-  RepoRole,
-} from 'src/resources/RepositoryResource';
-import {Entity} from 'src/resources/UserResource';
+import {RepoMember, RepoRole} from 'src/resources/RepositoryResource';
+import {Entity, getMemberType} from 'src/resources/UserResource';
 import {roles} from './Types';
 
 export default function AddPermissions(props: AddPermissionsProps) {
-  const [isUserOpen, setIsUserOpen] = useState<boolean>(false);
   const [isPermissionOpen, setIsPermissionOpen] = useState<boolean>(false);
   const [role, setRole] = useState<RepoRole>(RepoRole.admin);
-  const {
-    entities,
-    isError: errorFetchingEntities,
-    searchTerm,
-    setSearchTerm,
-  } = useEntities(props.org);
+  const [selectedEntity, setSelectedEntity] = useState<Entity>(null);
+  const [errorFetchingEntities, setErrorFetchingEntities] =
+    useState<boolean>(false);
   const {
     setPermissions,
     errorSetPermissions: errorSettingPermissions,
     successSetPermissions: success,
     resetSetRepoPermissions,
   } = useUpdateRepositoryPermissions(props.org, props.repo);
-
-  const filteredEntities = entities.filter((e) => e.name === searchTerm);
-  const validInput = filteredEntities.length > 0;
-  const selectedEntity =
-    filteredEntities.length > 0 ? filteredEntities[0] : null;
-
-  const getMemberType = (entity: Entity) => {
-    if (entity.kind == MemberType.team) {
-      return MemberType.team;
-    } else if (entity.kind == MemberType.user && entity.is_robot) {
-      return MemberType.robot;
-    } else if (entity.kind == MemberType.user) {
-      return MemberType.user;
-    }
-  };
 
   const createPermission = () => {
     const member: RepoMember = {
@@ -94,33 +67,11 @@ export default function AddPermissions(props: AddPermissionsProps) {
       </Conditional>
       <Form id="add-permission-form">
         <FormGroup fieldId="user" label="Select a user" required>
-          <Select
-            isOpen={isUserOpen}
-            selections={searchTerm}
-            onSelect={(e, value) => {
-              setSearchTerm(value as string);
-              setIsUserOpen(!isUserOpen);
-            }}
-            onToggle={() => {
-              setIsUserOpen(!isUserOpen);
-            }}
-            variant={SelectVariant.typeahead}
-            onTypeaheadInputChanged={(value) => {
-              setSearchTerm(value);
-            }}
-            shouldResetOnSelect={true}
-            onClear={() => {
-              setSearchTerm('');
-            }}
-          >
-            {entities.map((e) => (
-              <SelectOption
-                key={e.name}
-                value={e.name}
-                description={getMemberType(e)}
-              />
-            ))}
-          </Select>
+          <EntitySearch
+            org={props.org}
+            onError={() => setErrorFetchingEntities(true)}
+            onSelect={(e: Entity) => setSelectedEntity(e)}
+          />
         </FormGroup>
         <FormGroup fieldId="permission" label="Select a permission" required>
           <Dropdown
@@ -146,7 +97,7 @@ export default function AddPermissions(props: AddPermissionsProps) {
         </FormGroup>
         <ActionGroup>
           <Button
-            isDisabled={!validInput}
+            isDisabled={selectedEntity == null}
             onClick={() => {
               createPermission();
             }}

--- a/src/routes/RepositoryDetails/Settings/Settings.tsx
+++ b/src/routes/RepositoryDetails/Settings/Settings.tsx
@@ -2,6 +2,7 @@ import {Flex, FlexItem, Tab, Tabs, TabTitleText} from '@patternfly/react-core';
 import {useState} from 'react';
 import {DrawerContentType} from 'src/routes/RepositoryDetails/Types';
 import Permissions from './Permissions';
+import Notifications from './Notifications';
 
 export default function Settings(props: SettingsProps) {
   const [activeTabIndex, setActiveTabIndex] = useState(0);
@@ -12,6 +13,17 @@ export default function Settings(props: SettingsProps) {
       id: 'userandrobotpermissions',
       content: (
         <Permissions
+          org={props.org}
+          repo={props.repo}
+          setDrawerContent={props.setDrawerContent}
+        />
+      ),
+    },
+    {
+      name: 'Events and notifications',
+      id: 'eventsandnotifications',
+      content: (
+        <Notifications
           org={props.org}
           repo={props.repo}
           setDrawerContent={props.setDrawerContent}

--- a/src/routes/RepositoryDetails/Types.ts
+++ b/src/routes/RepositoryDetails/Types.ts
@@ -1,4 +1,5 @@
 export enum DrawerContentType {
   None,
   AddPermission,
+  CreateNotification,
 }


### PR DESCRIPTION
Contains the following changes:
- List, filter, and create notifications
- Addition of an entity search, for lookup of users, robots, and teams
- Resolves rendering issue when using `FEATURE_UI_V2_REPO_SETTINGS: True`

Quay notifications have not been enabled yet since the notification toolbar still needs to be implemented in the header component. 

**How to test**
- Have an instance of quay running locally with the config `FEATURE_UI_V2_REPO_SETTINGS: True`
- Run `npm run quay:seed`
- Run `npm start`
- Visit `http://localhost:9000/repository/testorg/testrepo`
- Select `Events and notifications`